### PR TITLE
Скрипт adk-log.sh: append-only JSONL журнал прогонов

### DIFF
--- a/hooks/scripts/adk-log.sh
+++ b/hooks/scripts/adk-log.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Журнал прогонов: append-only JSONL. Использование:
+#   adk-log.sh <единица> key=value [key=value ...]
+# <единица> — имя файла без расширения (issue-<N> | autopilot-<дата>).
+# Пишет одну JSON-строку с timestamp в $ADK_LOGS_DIR либо
+# <корень проекта>/.adk/logs/<единица>.jsonl (папку создаёт).
+# При записи по дефолтному пути кладёт <корень>/.adk/.gitignore с "*" —
+# самоигнорирующаяся папка, корневой .gitignore проекта не трогается.
+set -u
+
+unit="${1:-}"
+if [ -z "$unit" ]; then
+  echo "usage: adk-log.sh <unit> key=value [key=value ...]" >&2
+  exit 1
+fi
+case "$unit" in
+  */*) echo "adk-log.sh: имя единицы не может содержать '/': $unit" >&2; exit 1 ;;
+esac
+shift
+
+root="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$root" ]; then
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || root="$PWD"
+fi
+
+if [ -n "${ADK_LOGS_DIR:-}" ]; then
+  logs_dir="$ADK_LOGS_DIR"
+else
+  logs_dir="$root/.adk/logs"
+  gi="$root/.adk/.gitignore"
+  [ -f "$gi" ] || { mkdir -p "$root/.adk" && printf '*\n' > "$gi"; }
+fi
+mkdir -p "$logs_dir"
+
+line=$(python3 -c '
+import json, sys, datetime
+
+pairs = sys.argv[1:]
+event = {"timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")}
+for p in pairs:
+    if "=" not in p:
+        continue
+    k, v = p.split("=", 1)
+    event[k] = v
+print(json.dumps(event, ensure_ascii=False))
+' "$@")
+
+printf '%s\n' "$line" >> "$logs_dir/$unit.jsonl"

--- a/hooks/scripts/adk-log.sh
+++ b/hooks/scripts/adk-log.sh
@@ -18,6 +18,13 @@ case "$unit" in
 esac
 shift
 
+for pair in "$@"; do
+  case "$pair" in
+    *=*) ;;
+    *) echo "adk-log.sh: аргумент без '=' проигнорирован бы молча: $pair" >&2; exit 1 ;;
+  esac
+done
+
 root="${CLAUDE_PROJECT_DIR:-}"
 if [ -z "$root" ]; then
   root=$(git rev-parse --show-toplevel 2>/dev/null) || root="$PWD"
@@ -36,13 +43,18 @@ line=$(python3 -c '
 import json, sys, datetime
 
 pairs = sys.argv[1:]
-event = {"timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")}
+event = {}
 for p in pairs:
-    if "=" not in p:
-        continue
     k, v = p.split("=", 1)
     event[k] = v
+# timestamp — служебное поле скрипта, неподменяемое переданными парами
+event["timestamp"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 print(json.dumps(event, ensure_ascii=False))
 ' "$@")
+status=$?
+if [ "$status" -ne 0 ] || [ -z "$line" ]; then
+  echo "adk-log.sh: не удалось собрать JSON-строку события" >&2
+  exit 1
+fi
 
 printf '%s\n' "$line" >> "$logs_dir/$unit.jsonl"

--- a/templates/base/gitignore
+++ b/templates/base/gitignore
@@ -5,6 +5,7 @@
 .env
 .env.*
 !.env.example
+.adk/
 node_modules/
 dist/
 build/

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -174,6 +174,85 @@ else
   fails=$((fails + 1))
 fi
 
+# ── Журнал (adk-log.sh) ──────────────────────────────────────────────────────
+LOGP="$TMP/logproj"
+mkdir -p "$LOGP"
+(cd "$LOGP" && git init -q -b main)
+
+CLAUDE_PROJECT_DIR="$LOGP" "$HOOKS/adk-log.sh" issue-1 event=start issue=1 >/dev/null 2>&1
+assert_exit "AC-1: adk-log: запись под дефолтным путём завершается успешно" 0 $?
+if [ -f "$LOGP/.adk/logs/issue-1.jsonl" ]; then
+  echo "PASS: AC-1: adk-log: запись создаёт файл в .adk/logs/"
+else
+  echo "FAIL: AC-1: adk-log: файл .adk/logs/issue-1.jsonl не создан"
+  fails=$((fails + 1))
+fi
+
+CLAUDE_PROJECT_DIR="$LOGP" "$HOOKS/adk-log.sh" issue-1 event=review verdict=APPROVE >/dev/null 2>&1
+lines=$(wc -l < "$LOGP/.adk/logs/issue-1.jsonl" | tr -d ' ')
+assert_exit "AC-1: adk-log: повторная запись дописывает вторую строку, не трёт первую" 2 "$lines"
+first_event=$(sed -n '1p' "$LOGP/.adk/logs/issue-1.jsonl" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("event",""))' 2>/dev/null)
+if [ "$first_event" = "start" ]; then
+  echo "PASS: AC-1: adk-log: первая строка не перезаписана вторым событием"
+else
+  echo "FAIL: AC-1: adk-log: первая строка изменилась (event=$first_event)"
+  fails=$((fails + 1))
+fi
+
+valid=$(python3 -c '
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    lines = [l for l in f if l.strip()]
+ok = len(lines) == 2
+for l in lines:
+    try:
+        d = json.loads(l)
+        if "timestamp" not in d or "event" not in d:
+            ok = False
+    except Exception:
+        ok = False
+print("1" if ok else "0")
+' "$LOGP/.adk/logs/issue-1.jsonl")
+assert_exit "AC-1: adk-log: каждая строка — валидный JSON с timestamp и полями" 1 "$valid"
+
+CUSTOM="$TMP/customlogs"
+rm -rf "$CUSTOM"
+ADK_LOGS_DIR="$CUSTOM" CLAUDE_PROJECT_DIR="$LOGP" "$HOOKS/adk-log.sh" autopilot-2026-08-07 event=run_start >/dev/null 2>&1
+if [ -f "$CUSTOM/autopilot-2026-08-07.jsonl" ] && [ ! -f "$LOGP/.adk/logs/autopilot-2026-08-07.jsonl" ]; then
+  echo "PASS: AC-1: adk-log: ADK_LOGS_DIR переопределяет путь"
+else
+  echo "FAIL: AC-1: adk-log: ADK_LOGS_DIR не переопределил путь"
+  fails=$((fails + 1))
+fi
+
+gi_content=$(cat "$LOGP/.adk/.gitignore" 2>/dev/null)
+if [ "$gi_content" = "*" ]; then
+  echo "PASS: AC-1: adk-log: .adk/.gitignore создан с содержимым *"
+else
+  echo "FAIL: AC-1: adk-log: .adk/.gitignore отсутствует или содержит не *"
+  fails=$((fails + 1))
+fi
+
+adk_status=$(cd "$LOGP" && git status --porcelain -- .adk 2>/dev/null)
+if [ -z "$adk_status" ]; then
+  echo "PASS: AC-1: adk-log: git status пуст для .adk/ (самоигнорирующаяся папка)"
+else
+  echo "FAIL: AC-1: adk-log: .adk/ виден git status: $adk_status"
+  fails=$((fails + 1))
+fi
+
+CLAUDE_PROJECT_DIR="$LOGP" "$HOOKS/adk-log.sh" issue-1 event=merge >/dev/null 2>&1
+gi_lines_after=$(wc -l < "$LOGP/.adk/.gitignore" | tr -d ' ')
+assert_exit "AC-1: adk-log: повторная запись не дублирует .adk/.gitignore" 1 "$gi_lines_after"
+
+if grep -qx '\.adk/' "$KIT/templates/base/gitignore"; then
+  echo "PASS: AC-1: adk-log: templates/base/gitignore содержит .adk/"
+else
+  echo "FAIL: AC-1: adk-log: templates/base/gitignore не содержит .adk/"
+  fails=$((fails + 1))
+fi
+
 # ── Монорепа: корневой диспетчер ─────────────────────────────────────────────
 M="$TMP/mono"
 mkdir -p "$M/scripts" "$M/apps/web/scripts" "$M/apps/web/src" "$M/apps/api/scripts" "$M/apps/api/src"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -203,7 +203,7 @@ valid=$(python3 -c '
 import json, sys
 path = sys.argv[1]
 with open(path) as f:
-    lines = [l for l in f if l.strip()]
+    lines = f.readlines()
 ok = len(lines) == 2
 for l in lines:
     try:
@@ -215,6 +215,21 @@ for l in lines:
 print("1" if ok else "0")
 ' "$LOGP/.adk/logs/issue-1.jsonl")
 assert_exit "AC-1: adk-log: каждая строка — валидный JSON с timestamp и полями" 1 "$valid"
+
+before_badpair=$(wc -l < "$LOGP/.adk/logs/issue-1.jsonl" | tr -d ' ')
+CLAUDE_PROJECT_DIR="$LOGP" "$HOOKS/adk-log.sh" issue-1 event badpair >/dev/null 2>&1
+assert_exit "AC-1: adk-log: аргумент без '=' отклоняется с ошибкой" 1 $?
+after_badpair=$(wc -l < "$LOGP/.adk/logs/issue-1.jsonl" | tr -d ' ')
+assert_exit "AC-1: adk-log: отклонённый аргумент не пишет строку в журнал" "$before_badpair" "$after_badpair"
+
+CLAUDE_PROJECT_DIR="$LOGP" "$HOOKS/adk-log.sh" issue-1 event=spoof timestamp=bogus >/dev/null 2>&1
+last_ts=$(tail -n1 "$LOGP/.adk/logs/issue-1.jsonl" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("timestamp",""))')
+if [ "$last_ts" = "bogus" ]; then
+  echo "FAIL: AC-1: adk-log: переданное поле timestamp затёрло служебное"
+  fails=$((fails + 1))
+else
+  echo "PASS: AC-1: adk-log: служебный timestamp не подменяется переданным полем"
+fi
 
 CUSTOM="$TMP/customlogs"
 rm -rf "$CUSTOM"


### PR DESCRIPTION
Closes #1

## Что сделано
- `hooks/scripts/adk-log.sh <единица> key=value [key=value ...]` — пишет
  одну JSON-строку (timestamp UTC + переданные пары) в `$ADK_LOGS_DIR`
  либо `<корень проекта>/.adk/logs/<единица>.jsonl` (папку создаёт).
  Append-only, корень проекта берётся из `CLAUDE_PROJECT_DIR`, иначе
  `git rev-parse --show-toplevel`, иначе `PWD`.
- Самоигнорирующаяся папка журнала: при записи по дефолтному пути
  скрипт кладёт `<корень>/.adk/.gitignore` с содержимым `*` (идемпотентно,
  только если файла ещё нет) — git не видит `.adk/` целиком, корневой
  `.gitignore` проекта не трогается. Это уточнение владельца из комментария
  к issue #1 (self-ignoring pattern вместо правки чужого `.gitignore` через
  SessionStart-хук); правка исходного DoD «добавить `.adk/` в `.gitignore`
  кита» снята тем же комментарием как ненужная.
- `templates/base/gitignore` дополнен строкой `.adk/` — косметика для
  новых проектов, не обязательна (self-ignore покрывает всё).

## Тесты
`tests/run.sh`, блок «Журнал (adk-log.sh)», описания помечены `AC-1`:
- запись создаёт файл в `.adk/logs/`;
- повторная запись дописывает вторую строку, не трёт первую;
- каждая строка — валидный JSON с `timestamp` и переданными полями;
- `ADK_LOGS_DIR` переопределяет путь;
- `.adk/.gitignore` создаётся с содержимым `*`, `git status --porcelain`
  для `.adk/` пуст;
- повторная запись не дублирует `.adk/.gitignore`;
- `templates/base/gitignore` содержит `.adk/`.

`./scripts/check` и `./scripts/test` зелёные.

ADR не заводился — решение о механизме self-ignore уже принято владельцем
в комментарии к issue, не новый архитектурный выбор в рамках этой задачи.