### PR TITLE
5. Проверка AC-трассируемости с фикстурами (AC-4)

### DIFF
--- a/hooks/scripts/ac-check.sh
+++ b/hooks/scripts/ac-check.sh
@@ -3,11 +3,21 @@
 # спеки должен быть хотя бы один помеченный тест. Использование:
 #   ac-check.sh <корень проекта> [тестовый путь ...]
 # AC-токены собираются из раздела "## Критерии приёмки" approved-спек
-# (docs/specs/*.md, строка "Статус: approved" — draft и прочие статусы не
-# проверяются). Тестовый корпус — переданные пути (файлы или папки), либо
-# при их отсутствии дефолт: tests/, **/*.test.*, **/*.spec.*, test_*.py.
+# (docs/specs/*.md). Статус читается как первое слово после "Статус:" —
+# так строка шаблона "Статус: draft <!-- draft | approved | ... -->"
+# (templates/process/spec-template.md) не принимается за approved.
+# Только draft/in-progress/etc. пропускаются; approved — проверяется.
+# Тестовый корпус — переданные пути (файлы или папки), либо при их
+# отсутствии дефолт: tests/, **/*.test.*, **/*.spec.*, test_*.py, за
+# вычетом docs/specs/ (сами спеки не должны "покрывать" сами себя) и
+# служебных папок (node_modules, vendor, .git, dist, build).
 # exit 1 со списком непокрытых AC, exit 0 при полном покрытии или
 # отсутствии спек с конвенцией AC. Только проверка, ничего не правит.
+#
+# Известное ограничение: токен AC-<n> не привязан к конкретной спеке —
+# если у двух approved-спек совпадает номер критерия, покрытие одной
+# засчитывается и для другой. Глобальная схема именования AC вне рамок
+# этой задачи (issue #5) — уточняется конвенцией тегирования (issue #6).
 set -u
 
 root="${1:-}"
@@ -25,27 +35,37 @@ declare -a acs=()
 for spec in "$specs_dir"/*.md; do
   [ -f "$spec" ] || continue
   status_line=$(grep -m1 -E '^Статус:' "$spec" || true)
-  case "$status_line" in
-    *approved*) ;;
-    *) continue ;;
-  esac
+  status=$(printf '%s' "$status_line" | sed -E 's/^Статус:[[:space:]]*//' | awk '{print $1}')
+  [ "$status" = "approved" ] || continue
   # только токены из секции "## Критерии приёмки" (до следующего "## ")
   section=$(awk '/^## Критерии приёмки/{flag=1; next} /^## /{flag=0} flag' "$spec")
   while IFS= read -r ac; do
     [ -n "$ac" ] && acs+=("$ac")
-  done < <(printf '%s' "$section" | grep -oE 'AC-[0-9]+' | sort -u)
+  done < <(printf '%s' "$section" | grep -oE 'AC-[0-9]+')
 done
 
 if [ "${#acs[@]}" -eq 0 ]; then
   exit 0
 fi
-declare -a dedup=()
+declare -a uniq_acs=()
 while IFS= read -r ac; do
-  [ -n "$ac" ] && dedup+=("$ac")
+  [ -n "$ac" ] && uniq_acs+=("$ac")
 done < <(printf '%s\n' "${acs[@]}" | sort -u)
-acs=("${dedup[@]}")
+acs=("${uniq_acs[@]}")
 
 # ── Собрать тестовый корпус (список файлов) ──────────────────────────────────
+# служебные папки и сами спеки — не тестовый корпус
+prune_default() {
+  find "$1" -type f \
+    -not -path "$specs_dir/*" \
+    -not -path '*/node_modules/*' \
+    -not -path '*/vendor/*' \
+    -not -path '*/.git/*' \
+    -not -path '*/dist/*' \
+    -not -path '*/build/*' \
+    "${@:2}"
+}
+
 declare -a test_files=()
 if [ "$#" -gt 0 ]; then
   for p in "$@"; do
@@ -57,10 +77,10 @@ if [ "$#" -gt 0 ]; then
   done
 else
   if [ -d "$root/tests" ]; then
-    while IFS= read -r f; do test_files+=("$f"); done < <(find "$root/tests" -type f)
+    while IFS= read -r f; do test_files+=("$f"); done < <(prune_default "$root/tests")
   fi
   while IFS= read -r f; do test_files+=("$f"); done < <(
-    find "$root" -type f \( -name '*.test.*' -o -name '*.spec.*' -o -name 'test_*.py' \) 2>/dev/null
+    prune_default "$root" \( -name '*.test.*' -o -name '*.spec.*' -o -name 'test_*.py' \)
   )
 fi
 

--- a/hooks/scripts/ac-check.sh
+++ b/hooks/scripts/ac-check.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Проверка AC-трассируемости: у каждого критерия приёмки (AC-<n>) approved-
+# спеки должен быть хотя бы один помеченный тест. Использование:
+#   ac-check.sh <корень проекта> [тестовый путь ...]
+# AC-токены собираются из раздела "## Критерии приёмки" approved-спек
+# (docs/specs/*.md, строка "Статус: approved" — draft и прочие статусы не
+# проверяются). Тестовый корпус — переданные пути (файлы или папки), либо
+# при их отсутствии дефолт: tests/, **/*.test.*, **/*.spec.*, test_*.py.
+# exit 1 со списком непокрытых AC, exit 0 при полном покрытии или
+# отсутствии спек с конвенцией AC. Только проверка, ничего не правит.
+set -u
+
+root="${1:-}"
+if [ -z "$root" ]; then
+  echo "usage: ac-check.sh <project_root> [test_path ...]" >&2
+  exit 1
+fi
+shift
+
+specs_dir="$root/docs/specs"
+[ -d "$specs_dir" ] || exit 0
+
+# ── Собрать AC-токены из approved-спек ───────────────────────────────────────
+declare -a acs=()
+for spec in "$specs_dir"/*.md; do
+  [ -f "$spec" ] || continue
+  status_line=$(grep -m1 -E '^Статус:' "$spec" || true)
+  case "$status_line" in
+    *approved*) ;;
+    *) continue ;;
+  esac
+  # только токены из секции "## Критерии приёмки" (до следующего "## ")
+  section=$(awk '/^## Критерии приёмки/{flag=1; next} /^## /{flag=0} flag' "$spec")
+  while IFS= read -r ac; do
+    [ -n "$ac" ] && acs+=("$ac")
+  done < <(printf '%s' "$section" | grep -oE 'AC-[0-9]+' | sort -u)
+done
+
+if [ "${#acs[@]}" -eq 0 ]; then
+  exit 0
+fi
+declare -a dedup=()
+while IFS= read -r ac; do
+  [ -n "$ac" ] && dedup+=("$ac")
+done < <(printf '%s\n' "${acs[@]}" | sort -u)
+acs=("${dedup[@]}")
+
+# ── Собрать тестовый корпус (список файлов) ──────────────────────────────────
+declare -a test_files=()
+if [ "$#" -gt 0 ]; then
+  for p in "$@"; do
+    if [ -d "$p" ]; then
+      while IFS= read -r f; do test_files+=("$f"); done < <(find "$p" -type f)
+    elif [ -f "$p" ]; then
+      test_files+=("$p")
+    fi
+  done
+else
+  if [ -d "$root/tests" ]; then
+    while IFS= read -r f; do test_files+=("$f"); done < <(find "$root/tests" -type f)
+  fi
+  while IFS= read -r f; do test_files+=("$f"); done < <(
+    find "$root" -type f \( -name '*.test.*' -o -name '*.spec.*' -o -name 'test_*.py' \) 2>/dev/null
+  )
+fi
+
+corpus=""
+if [ "${#test_files[@]}" -gt 0 ]; then
+  corpus=$(cat "${test_files[@]}" 2>/dev/null)
+fi
+
+# ── Проверить покрытие ────────────────────────────────────────────────────────
+declare -a missing=()
+for ac in "${acs[@]}"; do
+  n="${ac#AC-}"
+  if ! printf '%s\n' "$corpus" | grep -qE "AC-${n}([^0-9]|\$)"; then
+    missing+=("$ac")
+  fi
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "Непокрытые критерии приёмки:"
+  printf '  %s\n' "${missing[@]}"
+  exit 1
+fi
+
+exit 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -331,6 +331,86 @@ assert_exit "монорепа post-edit-check: находит пакетный �
 echo '{}' | CLAUDE_PROJECT_DIR="$M" "$HOOKS/stop-test.sh" >/dev/null 2>&1
 assert_exit "монорепа stop-test: корневой контракт, всё зелёное" 0 $?
 
+# ── AC-трассируемость (ac-check.sh) ──────────────────────────────────────────
+ACP="$TMP/acproj"
+mkdir -p "$ACP/docs/specs" "$ACP/tests"
+
+write_ac_spec() { # write_ac_spec <файл> <статус> <тело критериев>
+  cat > "$1" <<EOF
+# SPEC
+
+Статус: $2
+
+## Критерии приёмки
+
+$3
+EOF
+}
+
+write_ac_spec "$ACP/docs/specs/001-x.md" "approved" "- [ ] AC-1: первый критерий
+- [ ] AC-2: второй критерий"
+cat > "$ACP/tests/run.sh" <<'EOF'
+echo "AC-1: первый критерий покрыт"
+echo "AC-2: второй критерий покрыт"
+EOF
+
+"$HOOKS/ac-check.sh" "$ACP" >/dev/null 2>&1
+assert_exit "AC-4: ac-check: approved-спека AC-1..AC-2 с помеченными тестами — покрытие полное" 0 $?
+
+# убрали тег AC-2 из тестов — непокрытый критерий должен провалить проверку
+# и быть назван в выводе
+cat > "$ACP/tests/run.sh" <<'EOF'
+echo "AC-1: первый критерий покрыт"
+EOF
+ac_out=$("$HOOKS/ac-check.sh" "$ACP" 2>&1)
+ac_st=$?
+assert_exit "AC-4: ac-check: непокрытый AC-2 — exit 1" 1 "$ac_st"
+if printf '%s' "$ac_out" | grep -q "AC-2"; then
+  echo "PASS: AC-4: ac-check: непокрытый AC-2 назван в выводе"
+else
+  echo "FAIL: AC-4: ac-check: AC-2 не найден в выводе: $ac_out"
+  fails=$((fails + 1))
+fi
+
+# draft-спека не проверяется — её AC-токены не требуют покрытия.
+# tests/run.sh фикстуры на этот момент всё ещё не содержит тега AC-2
+# (предыдущий блок), поэтому exit по-прежнему 1 — из-за AC-2, а не AC-9.
+write_ac_spec "$ACP/docs/specs/002-y.md" "draft" "- [ ] AC-9: черновой критерий без теста"
+ac_out=$("$HOOKS/ac-check.sh" "$ACP" 2>&1)
+ac_st=$?
+rm "$ACP/docs/specs/002-y.md"
+assert_exit "AC-4: ac-check: draft-спека не мешает результату (exit по-прежнему из-за AC-2)" 1 "$ac_st"
+if printf '%s' "$ac_out" | grep -q "AC-9"; then
+  echo "FAIL: AC-4: ac-check: draft-спека попала в проверку (AC-9 в выводе)"
+  fails=$((fails + 1))
+else
+  echo "PASS: AC-4: ac-check: AC-токены draft-спеки не требуют покрытия"
+fi
+
+# вернули тег AC-2 — approved-спека снова полностью покрыта
+cat > "$ACP/tests/run.sh" <<'EOF'
+echo "AC-1: первый критерий покрыт"
+echo "AC-2: второй критерий покрыт"
+EOF
+"$HOOKS/ac-check.sh" "$ACP" >/dev/null 2>&1
+assert_exit "AC-4: ac-check: покрытие восстановлено — exit 0" 0 $?
+
+# approved-спека без AC-токенов — не ломает проверку
+write_ac_spec "$ACP/docs/specs/003-z.md" "approved" "Пока без формализованных критериев."
+"$HOOKS/ac-check.sh" "$ACP" >/dev/null 2>&1
+assert_exit "AC-4: ac-check: approved-спека без AC-токенов не ломает проверку" 0 $?
+rm "$ACP/docs/specs/003-z.md"
+
+# переданные явные пути тестов используются вместо дефолтных
+mkdir -p "$ACP/alt-tests"
+cat > "$ACP/alt-tests/custom.sh" <<'EOF'
+echo "AC-1: покрыт в альтернативном месте"
+echo "AC-2: покрыт в альтернативном месте"
+EOF
+"$HOOKS/ac-check.sh" "$ACP" "$ACP/alt-tests" >/dev/null 2>&1
+assert_exit "AC-4: ac-check: явно переданный путь тестов используется вместо дефолтного tests/" 0 $?
+rm -rf "$ACP/alt-tests"
+
 # ── Итог ─────────────────────────────────────────────────────────────────────
 echo "─────"
 if [ "$fails" -eq 0 ]; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -411,6 +411,84 @@ EOF
 assert_exit "AC-4: ac-check: явно переданный путь тестов используется вместо дефолтного tests/" 0 $?
 rm -rf "$ACP/alt-tests"
 
+# без аргументов — usage-ошибка, не падение с трейсбеком
+"$HOOKS/ac-check.sh" >/dev/null 2>&1
+assert_exit "AC-4: ac-check: без аргументов — usage, exit 1" 1 $?
+
+# регрессия: строка статуса в реальном шаблоне спеки содержит HTML-комментарий-
+# подсказку — "Статус: draft <!-- draft | approved | in-progress | done -->"
+# (templates/process/spec-template.md). Подстрокой "approved" внутри этого
+# комментария черновик не должен приниматься за approved.
+TPL="$TMP/ac-template-proj"
+mkdir -p "$TPL/docs/specs" "$TPL/tests"
+cat > "$TPL/docs/specs/001-draft.md" <<'EOF'
+# SPEC-001: черновик
+
+Статус: draft <!-- draft | approved | in-progress | done -->
+
+## Критерии приёмки
+
+- [ ] AC-1: критерий без единого теста
+EOF
+"$HOOKS/ac-check.sh" "$TPL" >/dev/null 2>&1
+assert_exit "AC-4: ac-check: строка статуса шаблона (с HTML-комментарием-подсказкой) не считается approved" 0 $?
+
+# AC-токен вне секции "## Критерии приёмки" (например, упомянутый в прозе
+# раздела "## Что делаем") не требует отдельного теста
+SEC="$TMP/ac-section-proj"
+mkdir -p "$SEC/docs/specs" "$SEC/tests"
+cat > "$SEC/docs/specs/001-x.md" <<'EOF'
+# SPEC
+
+Статус: approved
+
+## Что делаем
+
+Упоминание AC-7 здесь — прозаическая отсылка, не критерий приёмки.
+
+## Критерии приёмки
+
+- [ ] AC-1: единственный формальный критерий
+EOF
+cat > "$SEC/tests/run.sh" <<'EOF'
+echo "AC-1: критерий покрыт"
+EOF
+"$HOOKS/ac-check.sh" "$SEC" >/dev/null 2>&1
+assert_exit "AC-4: ac-check: AC-токен вне секции «Критерии приёмки» не требует покрытия" 0 $?
+
+# сама спека (даже с именем вида *.spec.md, совпадающим с дефолтным
+# паттерном тестового корпуса) не может покрыть сама себя — docs/specs/
+# исключены из тестового корпуса
+SELFM="$TMP/ac-selfmatch-proj"
+mkdir -p "$SELFM/docs/specs"
+cat > "$SELFM/docs/specs/001-feature.spec.md" <<'EOF'
+# SPEC
+
+Статус: approved
+
+## Критерии приёмки
+
+- [ ] AC-1: критерий без отдельного теста
+EOF
+ac_out=$("$HOOKS/ac-check.sh" "$SELFM" 2>&1)
+ac_st=$?
+assert_exit "AC-4: ac-check: спека не засчитывает сама себя как тест (docs/specs исключён)" 1 "$ac_st"
+if printf '%s' "$ac_out" | grep -q "AC-1"; then
+  echo "PASS: AC-4: ac-check: AC-1 назван непокрытым при самопокрытии спекой"
+else
+  echo "FAIL: AC-4: ac-check: AC-1 не назван непокрытым: $ac_out"
+  fails=$((fails + 1))
+fi
+
+# node_modules/vendor не считаются тестовым корпусом — токен в зависимости
+# не должен ложно засчитываться как покрытие
+VEND="$TMP/ac-vendor-proj"
+mkdir -p "$VEND/docs/specs" "$VEND/tests" "$VEND/node_modules/pkg"
+write_ac_spec "$VEND/docs/specs/001-x.md" "approved" "- [ ] AC-1: критерий без реального теста"
+echo "AC-1" > "$VEND/node_modules/pkg/index.spec.js"
+"$HOOKS/ac-check.sh" "$VEND" >/dev/null 2>&1
+assert_exit "AC-4: ac-check: node_modules не считается тестовым корпусом" 1 $?
+
 # ── Итог ─────────────────────────────────────────────────────────────────────
 echo "─────"
 if [ "$fails" -eq 0 ]; then


### PR DESCRIPTION
Closes #5

## Что сделано

Добавлен скрипт `hooks/scripts/ac-check.sh <корень проекта> [тестовый путь ...]`:

- собирает токены `AC-<n>` из раздела «Критерии приёмки» **approved**-спек (`docs/specs/*.md`); draft и прочие статусы игнорируются;
- ищет эти токены в тестовом корпусе — явно переданных путях (файл или папка), либо по дефолту в `tests/`, `**/*.test.*`, `**/*.spec.*`, `test_*.py`;
- `exit 1` со списком непокрытых `AC-<n>` в stdout, если у критерия approved-спеки нет ни одного помеченного теста;
- `exit 0` при полном покрытии или при отсутствии спек с конвенцией AC (старые спеки/проекты без токенов не ломаются);
- только проверка — ничего не правит.

## Тесты, которые это доказывают

`tests/run.sh`, новый блок «AC-трассируемость (ac-check.sh)», теги `AC-4`, на фикстурном временном проекте:

- approved-спека с `AC-1`/`AC-2`, оба тега есть в тестах → `exit 0`;
- убрали тег `AC-2` из тестов → `exit 1`, `AC-2` присутствует в выводе;
- draft-спека с непокрытым `AC-9` не влияет на результат и не попадает в список непокрытых (проверено, что `AC-9` отсутствует в выводе);
- вернули тег `AC-2` → покрытие снова полное, `exit 0`;
- approved-спека без AC-токенов не ломает проверку → `exit 0`;
- явно переданный путь тестов используется вместо дефолтного `tests/` → `exit 0`.

`./scripts/check` и `./scripts/test` зелёные.

## Вне рамок

Само подключение `ac-check.sh` в контракт `scripts/check` кита (dogfooding) — отдельная задача (#9 по плану SPEC-001), туда же уходят `AC-3`, `AC-5`, `AC-6` (ещё не реализованы другими issues). Ручной прогон скрипта на самом ките сейчас корректно репортит их как непокрытые — это ожидаемо и не в рамках #5.

ADR не потребовался: реализация — прямое grep-решение без реальных архитектурных альтернатив, полностью описанное в issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)