### PR TITLE
fix(hooks): post-edit-check не путает templates/*/scripts/check с корнем проекта

### DIFF
--- a/hooks/scripts/post-edit-check.sh
+++ b/hooks/scripts/post-edit-check.sh
@@ -15,14 +15,25 @@ except Exception:
 [ -n "$file_path" ] || exit 0
 [ -f "$file_path" ] || exit 0
 
-# корень проекта = ближайший родитель файла, содержащий scripts/check
+# корень проекта = ближайший родитель файла, содержащий scripts/check.
+# Каталог внутри templates/ (например templates/nextjs) сам может нести
+# исполняемый scripts/check — это демонстрационный контракт шаблона, а не
+# корень проекта. Такой каталог пропускаем и ищем дальше вверх, иначе
+# root ложно зафиксируется на шаблоне раньше, чем на реальном корне кита
+# (issue #14): исключение "$root"/templates/* ниже рассчитано на root =
+# корень кита и не сработает, если root = сам каталог шаблона.
 dir=$(cd "$(dirname "$file_path")" 2>/dev/null && pwd) || exit 0
 root=""
 while [ "$dir" != "/" ]; do
-  if [ -x "$dir/scripts/check" ]; then
-    root="$dir"
-    break
-  fi
+  case "$dir" in
+    */templates/*) ;;
+    *)
+      if [ -x "$dir/scripts/check" ]; then
+        root="$dir"
+        break
+      fi
+      ;;
+  esac
   dir=$(dirname "$dir")
 done
 [ -n "$root" ] || exit 0

--- a/hooks/scripts/post-edit-check.sh
+++ b/hooks/scripts/post-edit-check.sh
@@ -15,25 +15,36 @@ except Exception:
 [ -n "$file_path" ] || exit 0
 [ -f "$file_path" ] || exit 0
 
-# корень проекта = ближайший родитель файла, содержащий scripts/check.
-# Каталог внутри templates/ (например templates/nextjs) сам может нести
-# исполняемый scripts/check — это демонстрационный контракт шаблона, а не
-# корень проекта. Такой каталог пропускаем и ищем дальше вверх, иначе
-# root ложно зафиксируется на шаблоне раньше, чем на реальном корне кита
-# (issue #14): исключение "$root"/templates/* ниже рассчитано на root =
-# корень кита и не сработает, если root = сам каталог шаблона.
+# Каталог внутри templates/ кита сам может нести исполняемый scripts/check —
+# демонстрационный контракт шаблона, а не корень проекта. Такой каталог не
+# должен фиксироваться как root раньше настоящего корня кита (issue #14):
+# исключение "$root"/templates/* ниже рассчитано на root = корень кита и не
+# сработает, если root = сам каталог шаблона. Отличаем "templates/ кита" от
+# случайного каталога templates/ в пути стороннего проекта (или пакета со
+# своим контрактом внутри templates/ в монорепе — тот контракт должен
+# по-прежнему работать) по маркеру корня кита: .claude-plugin/plugin.json —
+# манифест Claude Code плагина, лежащий только в корне самого кита.
+in_kit_templates() { # $1: каталог-кандидат в root — лежит ли он внутри
+                      # templates/ каталога, чей родитель — корень кита
+  s="$1"
+  while [ "$s" != "/" ]; do
+    p=$(dirname "$s")
+    if [ "$(basename "$s")" = "templates" ] && [ -f "$p/.claude-plugin/plugin.json" ]; then
+      return 0
+    fi
+    s="$p"
+  done
+  return 1
+}
+
+# корень проекта = ближайший родитель файла, содержащий scripts/check
 dir=$(cd "$(dirname "$file_path")" 2>/dev/null && pwd) || exit 0
 root=""
 while [ "$dir" != "/" ]; do
-  case "$dir" in
-    */templates/*) ;;
-    *)
-      if [ -x "$dir/scripts/check" ]; then
-        root="$dir"
-        break
-      fi
-      ;;
-  esac
+  if [ -x "$dir/scripts/check" ] && ! in_kit_templates "$dir"; then
+    root="$dir"
+    break
+  fi
   dir=$(dirname "$dir")
 done
 [ -n "$root" ] || exit 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -51,6 +51,27 @@ assert_exit "post-edit-check: чистый файл проходит" 0 $?
 printf '{"tool_input":{"file_path":"%s"}}' "$TMP/outside.txt" | "$HOOKS/post-edit-check.sh" >/dev/null 2>&1
 assert_exit "post-edit-check: файл вне проекта с контрактом пропускается" 0 $?
 
+# post-edit-check: правка templates/*/scripts/check не должна ложно фейлить
+# (issue #14). Поиск корня останавливался на самом каталоге шаблона — там
+# уже лежит исполняемый scripts/check, — и исключение "$root"/templates/*
+# после этого не срабатывало, т.к. рассчитано на root = корень кита.
+# Кит-подобная структура: свой scripts/check в корне (проходит) и
+# templates/demo/scripts/check (падает, если его реально прогнать —
+# имитирует контракт шаблона, нерелевантный правке самого файла шаблона).
+KITSIM="$TMP/kitsim"
+mkdir -p "$KITSIM/scripts" "$KITSIM/templates/demo/scripts"
+cat > "$KITSIM/scripts/check" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$KITSIM/templates/demo/scripts/check" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$KITSIM/scripts/check" "$KITSIM/templates/demo/scripts/check"
+printf '{"tool_input":{"file_path":"%s"}}' "$KITSIM/templates/demo/scripts/check" | "$HOOKS/post-edit-check.sh" >/dev/null 2>&1
+assert_exit "post-edit-check: правка шаблонного templates/*/scripts/check не запускает контракт кита (issue #14)" 0 $?
+
 # stop-test
 touch "$P/.fail-tests"
 echo '{}' | CLAUDE_PROJECT_DIR="$P" "$HOOKS/stop-test.sh" >/dev/null 2>&1

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -51,15 +51,15 @@ assert_exit "post-edit-check: чистый файл проходит" 0 $?
 printf '{"tool_input":{"file_path":"%s"}}' "$TMP/outside.txt" | "$HOOKS/post-edit-check.sh" >/dev/null 2>&1
 assert_exit "post-edit-check: файл вне проекта с контрактом пропускается" 0 $?
 
-# post-edit-check: правка templates/*/scripts/check не должна ложно фейлить
-# (issue #14). Поиск корня останавливался на самом каталоге шаблона — там
-# уже лежит исполняемый scripts/check, — и исключение "$root"/templates/*
-# после этого не срабатывало, т.к. рассчитано на root = корень кита.
-# Кит-подобная структура: свой scripts/check в корне (проходит) и
-# templates/demo/scripts/check (падает, если его реально прогнать —
-# имитирует контракт шаблона, нерелевантный правке самого файла шаблона).
+# post-edit-check: правка templates/*/scripts/check в корне кита не должна
+# ложно фейлить (issue #14) — см. комментарий у in_kit_templates() в
+# post-edit-check.sh. Кит-подобная структура: маркер .claude-plugin/plugin.json,
+# свой scripts/check в корне (проходит) и templates/demo/scripts/check
+# (падает, если его реально прогнать — имитирует контракт шаблона,
+# нерелевантный правке самого файла шаблона).
 KITSIM="$TMP/kitsim"
-mkdir -p "$KITSIM/scripts" "$KITSIM/templates/demo/scripts"
+mkdir -p "$KITSIM/.claude-plugin" "$KITSIM/scripts" "$KITSIM/templates/demo/scripts"
+echo '{}' > "$KITSIM/.claude-plugin/plugin.json"
 cat > "$KITSIM/scripts/check" <<'EOF'
 #!/usr/bin/env bash
 exit 0
@@ -70,7 +70,39 @@ exit 1
 EOF
 chmod +x "$KITSIM/scripts/check" "$KITSIM/templates/demo/scripts/check"
 printf '{"tool_input":{"file_path":"%s"}}' "$KITSIM/templates/demo/scripts/check" | "$HOOKS/post-edit-check.sh" >/dev/null 2>&1
-assert_exit "post-edit-check: правка шаблонного templates/*/scripts/check не запускает контракт кита (issue #14)" 0 $?
+assert_exit "post-edit-check: правка шаблонного templates/*/scripts/check в корне кита не запускает контракт кита (issue #14)" 0 $?
+
+# post-edit-check: сторонний проект, у которого в пути случайно есть каталог
+# "templates" (нет маркера кита .claude-plugin/plugin.json рядом) — не кит,
+# его контракт должен по-прежнему отрабатывать как обычно (регрессия фикса
+# issue #14: пропуск каталогов templates/ не должен быть шире, чем "templates/
+# именно у корня кита").
+NOKIT="$TMP/no-kit-marker/templates/myapp"
+mkdir -p "$NOKIT/scripts" "$NOKIT/src"
+cat > "$NOKIT/scripts/check" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do case "$a" in *bad*) exit 1;; esac; done
+exit 0
+EOF
+chmod +x "$NOKIT/scripts/check"
+echo x > "$NOKIT/src/bad.ts"
+printf '{"tool_input":{"file_path":"%s"}}' "$NOKIT/src/bad.ts" | "$HOOKS/post-edit-check.sh" >/dev/null 2>&1
+assert_exit "post-edit-check: проект с 'templates' в пути без маркера кита проверяется как обычно" 2 $?
+
+# post-edit-check: пакет со своим контрактом внутри templates/ монорепы, у
+# которой нет маркера кита — контракт пакета должен по-прежнему отрабатывать
+# (та же регрессия: не спутать любой каталог templates/ с templates/ кита).
+MONOPKG="$TMP/mono-no-kit/templates/mail"
+mkdir -p "$MONOPKG/scripts" "$MONOPKG/src"
+cat > "$MONOPKG/scripts/check" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do case "$a" in *bad*) exit 1;; esac; done
+exit 0
+EOF
+chmod +x "$MONOPKG/scripts/check"
+echo x > "$MONOPKG/src/bad.ts"
+printf '{"tool_input":{"file_path":"%s"}}' "$MONOPKG/src/bad.ts" | "$HOOKS/post-edit-check.sh" >/dev/null 2>&1
+assert_exit "post-edit-check: пакет со своим контрактом внутри templates/ монорепы без маркера кита проверяется как обычно" 2 $?
 
 # stop-test
 touch "$P/.fail-tests"


### PR DESCRIPTION
Closes #14

## Проблема
`hooks/scripts/post-edit-check.sh` ложно репортил провал при редактировании файлов `templates/*/scripts/check`. Поиск корня проекта останавливался на самом каталоге шаблона (там уже лежит исполняемый `scripts/check` — демонстрационный контракт шаблона), и исключение `case "$file_path" in "$root"/templates/*)` не срабатывало, потому что рассчитано на `root` = корень кита, а не `root` = каталог конкретного шаблона. В итоге правка `templates/nextjs/scripts/check` (и аналогичных) прогоняла контракт шаблона против самой себя и ложно блокировала правку.

## Что сделано
- `hooks/scripts/post-edit-check.sh`: добавлена функция `in_kit_templates()` — точный маркер корня кита, `.claude-plugin/plugin.json` (манифест Claude Code плагина, есть только в корне самого кита). Каталог внутри `templates/` кита теперь не может быть ложно принят как root проекта; поиск продолжается выше, к реальному корню.
  - Первая версия фикса (первый круг ревью) пропускала любой каталог с `/templates/` в пути — это отключало гейт для сторонних проектов, у которых в пути случайно есть каталог `templates`, и для пакетов со своим контрактом внутри `templates/` в монорепах. Заменено на точную проверку по маркеру, как и предлагал issue #14 ("явно проверять на маркер корня кита").

## Тесты, доказывающие фикс
- `tests/run.sh`: регрессионный кейс на синтетической кит-подобной структуре (маркер `.claude-plugin/plugin.json` + свой `scripts/check` в корне + `templates/demo/scripts/check`) — воспроизводит issue #14 (до фикса `FAIL exit 2`, после — `PASS exit 0`).
- `tests/run.sh`: два теста-стража на регрессии, найденные в первом круге ревью — сторонний проект с `templates` в пути без маркера кита, и пакет со своим контрактом внутри `templates/` монорепы без маркера кита — оба по-прежнему проверяются контрактом как обычно (`exit 2` на битом файле).
- Вручную проверен реальный сценарий из issue: правка `templates/nextjs/scripts/check` в этом репозитории — hook теперь возвращает `exit 0`.
- `./scripts/check` и `./scripts/test` — зелёные, вся существующая сюита не задета.

ADR не заводился — узкий bug-фикс в существующей логике поиска root, без новых архитектурных решений.

## Ревью
Круг 1 — REQUEST_CHANGES (эвристика по подстроке пути открывала ложноотрицательный обход гейта), исправлено маркер-based подходом. Круг 2 — APPROVE.