### PR TITLE
Consolidate hook JSON payload parsing into shared json_field helper (#22)

### DIFF
--- a/hooks/scripts/bash-guard.sh
+++ b/hooks/scripts/bash-guard.sh
@@ -4,14 +4,8 @@
 set -u
 
 payload=$(cat)
-cmd=$(printf '%s' "$payload" | python3 -c '
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    print(d.get("tool_input", {}).get("command", ""))
-except Exception:
-    pass
-')
+. "$(cd "$(dirname "$0")" && pwd)/lib/json-field.sh"
+cmd=$(json_field "$payload" "tool_input.command" "")
 [ -n "$cmd" ] || exit 0
 
 deny() {
@@ -23,13 +17,7 @@ deny() {
 # репозиторием (сессия открыта выше, проект подключён дополнительной
 # директорией), поэтому кандидаты в порядке достоверности: явный `cd` в самой
 # команде → cwd сессии из payload хука → корень сессии → PWD хука.
-hook_cwd=$(printf '%s' "$payload" | python3 -c '
-import json, sys
-try:
-    print(json.load(sys.stdin).get("cwd", ""))
-except Exception:
-    pass
-')
+hook_cwd=$(json_field "$payload" "cwd" "")
 cd_prefix=""
 case "$cmd" in
   cd\ *) cd_prefix=$(printf '%s' "$cmd" | sed -E 's/^cd +//; s/ *(&&|;|\|).*$//' | tr -d '"'"'"'') ;;

--- a/hooks/scripts/lib/json-field.sh
+++ b/hooks/scripts/lib/json-field.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Общий хелпер для хуков: достаёт поле из JSON-payload хука по пути через
+# точку (например "tool_input.file_path"). Один инлайн python3 вместо
+# отдельной копии в каждом хуке (issue #22) — до этой правки один и тот же
+# разбор stdin-JSON существовал в трёх слегка разных стилях в шести местах.
+#
+# Использование:
+#   value=$(json_field "$payload" "tool_input.file_path" "<дефолт>")
+#
+# Возвращает $3 (по умолчанию — пустая строка), если путь отсутствует в
+# JSON (на любом уровне вложенности) или сам payload не парсится как JSON.
+# Не предназначен для булевых полей уровня верхнего JSON (например
+# stop_hook_active) — вызывающий сам решает, как трактовать полученную
+# python-строку "True"/"False".
+json_field() {
+  local payload="$1" path="$2" default="${3:-}"
+  printf '%s' "$payload" | python3 -c '
+import json, sys
+
+path = sys.argv[1]
+default = sys.argv[2]
+try:
+    d = json.load(sys.stdin)
+    for key in path.split("."):
+        d = d.get(key) if isinstance(d, dict) else None
+        if d is None:
+            break
+    print(default if d is None else d)
+except Exception:
+    print(default)
+' "$path" "$default"
+}

--- a/hooks/scripts/notification.sh
+++ b/hooks/scripts/notification.sh
@@ -3,13 +3,8 @@
 set -u
 
 payload=$(cat)
-msg=$(printf '%s' "$payload" | python3 -c '
-import json, sys
-try:
-    print(json.load(sys.stdin).get("message", ""))
-except Exception:
-    pass
-')
+. "$(cd "$(dirname "$0")" && pwd)/lib/json-field.sh"
+msg=$(json_field "$payload" "message" "")
 [ -n "$msg" ] || msg="Claude ждёт вашего ответа"
 
 proj=$(basename "${CLAUDE_PROJECT_DIR:-$PWD}")

--- a/hooks/scripts/post-edit-check.sh
+++ b/hooks/scripts/post-edit-check.sh
@@ -4,14 +4,8 @@
 set -u
 
 payload=$(cat)
-file_path=$(printf '%s' "$payload" | python3 -c '
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    print(d.get("tool_input", {}).get("file_path", ""))
-except Exception:
-    pass
-')
+. "$(cd "$(dirname "$0")" && pwd)/lib/json-field.sh"
+file_path=$(json_field "$payload" "tool_input.file_path" "")
 [ -n "$file_path" ] || exit 0
 [ -f "$file_path" ] || exit 0
 

--- a/hooks/scripts/prompt-timestamp.sh
+++ b/hooks/scripts/prompt-timestamp.sh
@@ -5,13 +5,8 @@
 set -u
 
 payload=$(cat)
-sid=$(printf '%s' "$payload" | python3 -c '
-import json, sys
-try:
-    print(json.load(sys.stdin).get("session_id", ""))
-except Exception:
-    pass
-')
+. "$(cd "$(dirname "$0")" && pwd)/lib/json-field.sh"
+sid=$(json_field "$payload" "session_id" "")
 [ -n "$sid" ] || exit 0
 
 dir="${TMPDIR:-/tmp}/agent-dev-kit-notify"

--- a/hooks/scripts/stop-test.sh
+++ b/hooks/scripts/stop-test.sh
@@ -5,21 +5,15 @@
 set -u
 
 payload=$(cat)
-stop_active=$(printf '%s' "$payload" | python3 -c '
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    print("1" if d.get("stop_hook_active") else "0")
-except Exception:
-    print("0")
-')
-session_id=$(printf '%s' "$payload" | python3 -c '
-import json, sys
-try:
-    print(json.load(sys.stdin).get("session_id", ""))
-except Exception:
-    pass
-')
+. "$(cd "$(dirname "$0")" && pwd)/lib/json-field.sh"
+# stop_hook_active — JSON-булево; json_field возвращает python-строковое
+# представление ("True"/"False") или default при отсутствии поля/ошибке
+# разбора. Нормализуем к прежнему "1"/"0", чтобы проверка ниже не менялась.
+case "$(json_field "$payload" "stop_hook_active" "False")" in
+  True) stop_active=1 ;;
+  *) stop_active=0 ;;
+esac
+session_id=$(json_field "$payload" "session_id" "")
 
 # Уведомление «задача завершена» при успешном выходе (exit 0), если ход
 # длился дольше порога (ADK_NOTIFY_MIN_SECONDS, по умолчанию 45 с) —

--- a/scripts/check
+++ b/scripts/check
@@ -5,7 +5,7 @@
 set -eo pipefail
 cd "$(dirname "$0")/.."
 
-for f in hooks/scripts/* templates/*/scripts/* scripts/* tests/*.sh; do
+for f in hooks/scripts/* hooks/scripts/lib/* templates/*/scripts/* scripts/* tests/*.sh; do
   [ -f "$f" ] || continue
   bash -n "$f"
 done


### PR DESCRIPTION
Closes #22

## Что сделано

Заменил 7 инлайн-копий python3-парсинга JSON-payload хука (в 5 файлах,
в трёх слегка разных стилях: `d = json.load(...)` + вложенный `.get()`,
однострочный `json.load(sys.stdin).get(...)`, и вариант с `except: print("0")`)
на один общий хелпер `hooks/scripts/lib/json-field.sh` с функцией
`json_field <payload> <путь.через.точку> [default]`.

Затронутые хуки:
- `hooks/scripts/post-edit-check.sh` — `tool_input.file_path`
- `hooks/scripts/bash-guard.sh` — `tool_input.command` и `cwd`
- `hooks/scripts/stop-test.sh` — `stop_hook_active` и `session_id`
- `hooks/scripts/notification.sh` — `message`
- `hooks/scripts/prompt-timestamp.sh` — `session_id`

`scripts/check` дополнен глобом `hooks/scripts/lib/*`, чтобы новый
файл тоже проходил синтаксический `bash -n` (иначе он невидим для
существующего цикла проверки — `[ -f "$f" ]` пропускает каталог `lib/`
при непрямом глобе `hooks/scripts/*`).

## Особый случай: stop_hook_active (булево поле)

`stop-test.sh` раньше печатал `"1"`/`"0"` из питона напрямую. `json_field`
— это хелпер общего назначения для строковых полей и возвращает
python-строковое представление булева (`"True"`/`"False"`) или default.
Нормализация к прежнему внутреннему представлению `"1"`/`"0"` перенесена
в bash (`case ... True) stop_active=1 ;; *) stop_active=0 ;; esac`) —
условие ниже (`[ "$stop_active" = "1" ]`) не изменилось, только источник
значения.

## Доказательство эквивалентности поведения

`./scripts/check` и `./scripts/test` зелёные без правок тестов
(`tests/run.sh` не редактировался) — все существующие ассерты по
post-edit-check/bash-guard/stop-test/notification/prompt-timestamp
(exit-коды и побочные эффекты: файлы уведомлений, кэш тестов,
защита от Stop-цикла и т.д.) прошли как есть.

Дополнительно вручную прогнал по паре примеров payload на каждый из
пяти скриптов, сравнивая с поведением до правки:

- `post-edit-check.sh`: `{}` (нет `file_path`) → exit 0; `not json`
  (битый JSON) → exit 0 — как раньше, тихий пропуск.
- `bash-guard.sh`: `{}` (нет `tool_input.command`) → exit 0 — как раньше.
- `notification.sh`: `{}` (нет `message`) → уведомление с дефолтным
  текстом "Claude ждёт вашего ответа" — как раньше.
- `prompt-timestamp.sh`: `{}` (нет `session_id`) → exit 0, файл метки
  не создаётся — как раньше.
- `stop-test.sh`: `{"stop_hook_active":true}` → exit 0 (защита от
  цикла сработала); `{"stop_hook_active":false}` → обычный путь
  (exit 0 на чистом дереве) — как раньше.

Известное расхождение вне контракта хуков (не влияет на поведение
для реальных payload от Claude Code): при явном JSON `null` в значении
поля старый код печатал строку `"None"` (python `print(None)`), новый
`json_field` возвращает `default`. Например `{"message":null}` раньше
слал уведомление с текстом `"None"`, теперь — дефолтный текст;
`{"session_id":null}` раньше создавал файл метки с именем `None`,
теперь не создаёт. Ни один реальный hook payload Claude Code такого
не шлёт (`message`/`session_id`/`file_path`/`command`/`cwd` — всегда
строки, `stop_hook_active` — булево), это чинит теоретическую
латентную неточность, а не меняет наблюдаемое поведение кита.

Диф: ~72 строки (укладывается в оценку issue ~60 строк с учётом
добавленного файла хелпера и правки scripts/check).
