### PR TITLE
Добавить assert_contains/assert_not_contains/count_lines в tests/run.sh (#25)

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -20,6 +20,34 @@ assert_exit() { # assert_exit <описание> <ожидаемый_код> <ф
 
 git_c() { git -c user.email=t@t -c user.name=t "$@"; }
 
+assert_contains() { # assert_contains <описание> <текст> <подстрока>
+  if printf '%s' "$2" | grep -q -- "$3"; then
+    echo "PASS: $1"
+  else
+    echo "FAIL: $1 (не найдено: $3)"
+    fails=$((fails + 1))
+  fi
+}
+
+assert_not_contains() { # assert_not_contains <описание> <текст> <подстрока>
+  if printf '%s' "$2" | grep -q -- "$3"; then
+    echo "FAIL: $1 (неожиданно найдено: $3)"
+    fails=$((fails + 1))
+  else
+    echo "PASS: $1"
+  fi
+}
+
+count_lines() { # count_lines <файл> — обёртка над wc -l для сравнения через assert_exit
+  wc -l < "$1" | tr -d ' '
+}
+
+# демонстрация новых хелперов (issue #25) — не заменяет существующие сценарии
+assert_contains "demo: assert_contains находит подстроку" "hello world" "wor"
+assert_not_contains "demo: assert_not_contains не находит отсутствующую подстроку" "hello world" "xyz"
+printf 'a\nb\nc\n' > "$TMP/.count-demo"
+assert_exit "demo: count_lines считает строки файла" 3 "$(count_lines "$TMP/.count-demo")"
+
 # ── Одиночный проект с контрактом ────────────────────────────────────────────
 P="$TMP/proj"
 mkdir -p "$P/scripts" "$P/src"


### PR DESCRIPTION
Closes #25

## Что сделано
Добавлены три новых хелпера в `tests/run.sh`, рядом с существующими (`assert_exit`, `git_c`), до первого использования:
- `assert_contains <описание> <текст> <подстрока>`
- `assert_not_contains <описание> <текст> <подстрока>` (инвертированная версия)
- `count_lines <файл>` — обёртка над `wc -l < "$файл" | tr -d ' '`

## Что НЕ сделано (сознательно, вне рамок issue #25)
Существующие 54 ручных PASS/FAIL блока и 9 вызовов идиомы `wc -l < f | tr -d ' '` **не тронуты** — их миграция на новые хелперы вынесена в отдельный issue (заблокированный этим PR).

## Демонстрационные вызовы
Добавлены 3 демонстрационных вызова (по одному на каждую новую функцию), сразу после определений — единственные новые строки в выводе `./scripts/test`:
```
PASS: demo: assert_contains находит подстроку
PASS: demo: assert_not_contains не находит отсутствующую подстроку
PASS: demo: count_lines считает строки файла
```
Все прежние 160 PASS/0 FAIL строк (описания и порядок) подтверждены байт-в-байт идентичными через diff baseline vs after — итого 163 PASS / 0 FAIL.

## Гейты
- `./scripts/check` — OK
- `./scripts/test` — 163 PASS / 0 FAIL (160 существующих без изменений + 3 демо)