### PR TITLE
Добавить $#-guard в scripts/check кита вокруг ac-check (#24)

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -2,6 +2,9 @@
 # Контракт agent-dev-kit для самого кита: синтаксис bash, валидность JSON,
 # валидация плагина. Полный прогон занимает секунды, поэтому аргументы
 # (изменённые файлы) не сужают область — проверяем всё всегда.
+# С аргументами — без AC-трассируемости (см. docs/contract.md, issue #24):
+# частичный прогон зовёт post-edit-check после каждого Edit, а AC-check —
+# только хвост полного прогона, как и в templates/*/scripts/check.
 set -eo pipefail
 cd "$(dirname "$0")/.."
 
@@ -18,8 +21,10 @@ if command -v claude >/dev/null 2>&1; then
   claude plugin validate . >/dev/null 2>&1
 fi
 
-# трассируемость AC → тест: кит применяет свою же конвенцию к себе
-# (dogfood, issue #9); тестовая область — tests/run.sh.
-hooks/scripts/ac-check.sh . tests/run.sh
+if [ $# -eq 0 ]; then
+  # трассируемость AC → тест: кит применяет свою же конвенцию к себе
+  # (dogfood, issue #9); тестовая область — tests/run.sh.
+  hooks/scripts/ac-check.sh . tests/run.sh
+fi
 
 echo "check: OK"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -946,6 +946,45 @@ done
 project_init_content=$(cat "$KIT/commands/project-init.md")
 assert_contains "AC-4: project-init.md содержит шаг копирования ac-check.sh в scripts/ac-check" "$project_init_content" 'scripts/ac-check'
 
+# ── scripts/check самого кита применяет $#-guard к ac-check (issue #24) ──────
+# Реальный scripts/check кита копируется в изолированную фикстуру-кита:
+# hooks/scripts/ac-check.sh — стаб, печатающий маркер (отличить вызов от
+# невызова), claude-CLI на PATH — тоже стаб (реальный "claude plugin validate"
+# не должен зависеть от того, установлен ли claude в окружении, где гоняются
+# тесты кита).
+KCHK="$TMP/kitcheck"
+mkdir -p "$KCHK/.claude-plugin" "$KCHK/hooks/scripts" "$KCHK/scripts" "$KCHK/tests" "$KCHK/bin"
+echo '{}' > "$KCHK/.claude-plugin/plugin.json"
+echo '{}' > "$KCHK/.claude-plugin/marketplace.json"
+echo '{}' > "$KCHK/hooks/hooks.json"
+cp "$KIT/scripts/check" "$KCHK/scripts/check"
+chmod +x "$KCHK/scripts/check"
+cat > "$KCHK/hooks/scripts/ac-check.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "AC_CHECK_CALLED"
+exit 0
+EOF
+chmod +x "$KCHK/hooks/scripts/ac-check.sh"
+cat > "$KCHK/tests/run.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$KCHK/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$KCHK/bin/claude"
+
+kchk_out=$(cd "$KCHK" && PATH="$KCHK/bin:$PATH" ./scripts/check some/file.ts 2>&1)
+kchk_st=$?
+assert_exit "кит: scripts/check <файл> — частичный прогон завершается успешно" 0 "$kchk_st"
+assert_not_contains "кит: scripts/check <файл> не запускает ac-check.sh (issue #24)" "$kchk_out" "AC_CHECK_CALLED"
+
+kchk_out=$(cd "$KCHK" && PATH="$KCHK/bin:$PATH" ./scripts/check 2>&1)
+kchk_st=$?
+assert_exit "кит: scripts/check без аргументов — полный прогон завершается успешно" 0 "$kchk_st"
+assert_contains "кит: scripts/check без аргументов запускает ac-check.sh (issue #24)" "$kchk_out" "AC_CHECK_CALLED"
+
 # ── Конвенция AC-тегирования зафиксирована в промптах и скилле tdd (issue #6) ─
 # Только markdown: проверяем, что нужный текст конвенции присутствует в
 # правильном месте каждого из семи файлов, а не просто что "AC-" где-то


### PR DESCRIPTION
Closes #24

## Что сделано
- `scripts/check` кита теперь оборачивает вызов `hooks/scripts/ac-check.sh`
  в `if [ $# -eq 0 ]; then … fi` — тот же `$#`-guard, что уже используется
  во всех `templates/*/scripts/check` и предписан `docs/contract.md`
  («с аргументами — без AC-трассируемости»).
- Тест-регрессия в `tests/run.sh` (новый стиль: `assert_contains` /
  `assert_not_contains`): копирует реальный `scripts/check` кита в
  изолированную фикстуру со стаб-`ac-check.sh` (печатает маркер) и
  стаб-`claude` в PATH (чтобы `claude plugin validate` не зависело от
  окружения) — проверяет, что `scripts/check <файл>` не запускает
  ac-check, а `scripts/check` без аргументов запускает.

## Проверка
- `./scripts/check` — OK (полный прогон, ac-check отрабатывает штатно)
- `./scripts/check tests/run.sh` — OK (частичный прогон, без ac-check)
- `./scripts/test` — все тесты зелёные