### PR TITLE
Настроить сервер нового репозитория по конфигу в /project-init (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,16 @@ issue → ветка issue-N-слаг → падающие тесты из DoD �
 | `bash-guard` | Перед каждой Bash-командой | Запрещает `git commit --no-verify`, force push в main/master и `gh pr merge` вопреки `policies.merge` (дефолт `agent-after-approve`: merge только для ready-PR, т.е. после APPROVE; `human-review-required` — плюс человеческий approve на PR; `human-only` — запрет всегда; непроверяемый статус или неизвестное значение политики = запрет). Перед `git commit` сканирует изменения на секреты (ключи AWS/GitHub/Slack/Google, `sk-*`, приватные ключи) и блокирует коммит `.env` |
 | `pr-title-check` | После `gh pr create`/`gh pr edit` | При `conventions.commitStyle=conventional` сверяет фактический заголовок PR (`gh pr view`) с форматом `<commitType>[(scope)]: <суть> (#N)` и label'ом issue (`types.*` конфига); нарушение возвращается агенту с требованием исправить через `gh pr edit`. Выключается `conventions.externalTitleLint=true` |
 
-Плюс серверный гейт: `/project-init` предлагает включить branch protection —
-merge в main только через PR с зелёным CI, прямые пуши запрещены. Его не
-обойти даже локальным саботажем хуков.
+Плюс серверный гейт: новому репозиторию `/project-init` настраивает сервер
+по `adk.config.json`: единственный разрешённый метод приземления, производный от
+пары `conventions.squash` × `conventions.branchUpdate` (`squash=true` →
+squash-merge; `false`+`rebase` → rebase-merge; `false`+`merge` →
+merge-commit; выводится скриптом `adk-config.sh --merge-method`),
+автоудаление веток после merge (`delete_branch_on_merge`) и branch
+protection по `policies` — merge в main только через PR с зелёным CI,
+прямые пуши запрещены, а при `policies.review.humanApprovalRequired=true` —
+ещё и обязательный человеческий approve. Его не обойти даже локальным
+саботажем хуков.
 
 ### Уведомления
 

--- a/commands/project-init.md
+++ b/commands/project-init.md
@@ -109,14 +109,36 @@ argument-hint: "[путь к проекту; по умолчанию текущ�
    `── check: <пакет>` для каждого). Не завершай инициализацию с падающим
    контрактом — это фундамент всех гейтов.
 
-9. **Git.** Если репозитория нет — `git init -b main` и первый коммит.
-   Спроси про GitHub: если нужен remote — предложи `gh repo create`.
-   После создания remote предложи включить защиту main (серверный гейт,
-   который не обойти локально): merge только через PR с зелёным
-   required-чеком `gates`, прямые пуши и force push в main запрещены —
-   `gh api -X PUT repos/{owner}/{repo}/branches/main/protection` с
-   `required_status_checks.contexts=["gates"]`, `allow_force_pushes=false`,
-   `enforce_admins=false` (чтобы владелец мог мержить без апрувов).
+9. **Git и сервер нового репозитория.** Если репозитория нет —
+   `git init -b main` и первый коммит. Спроси про GitHub: если нужен
+   remote — предложи `gh repo create`. Сразу после создания remote настрой
+   сервер по конфигу (SPEC-002 AC-6) — серверный гейт, который не обойти
+   локально:
+   - **allowed merge methods** — по производному методу приземления:
+     `${CLAUDE_PLUGIN_ROOT}/hooks/scripts/adk-config.sh --merge-method`
+     выводит его из пары `conventions.squash` × `conventions.branchUpdate`
+     (сам метод в конфиге не хранится — не пытайся вычислить его сам,
+     используй вывод скрипта). Разреши только этот метод, запрети два
+     остальных: `gh api -X PATCH repos/{owner}/{repo}` с полями
+     `allow_squash_merge` / `allow_rebase_merge` / `allow_merge_commit`,
+     где `true` — ровно у одного, соответствующего выводу
+     (`squash-merge` → `allow_squash_merge`, `rebase-merge` →
+     `allow_rebase_merge`, `merge-commit` → `allow_merge_commit`);
+   - тем же вызовом — `delete_branch_on_merge=true`: ветки после
+     приземления удаляет сервер (`--delete-branch` в командах остаётся
+     страховкой для репозиториев без этой настройки);
+   - **branch protection согласно `policies`**: merge только через PR с
+     зелёным required-чеком `gates`, прямые пуши и force push в main
+     запрещены — `gh api -X PUT repos/{owner}/{repo}/branches/main/protection`
+     с `required_status_checks.contexts=["gates"]`,
+     `allow_force_pushes=false`, `enforce_admins=false`. Если
+     `adk-config.sh policies.review.humanApprovalRequired false` даёт
+     `true` — добавь `required_pull_request_reviews` с
+     `required_approving_review_count=1` (обязательный человеческий approve;
+     заодно GitHub начнёт заполнять `reviewDecision`, на который опирается
+     политика merge `human-review-required` — см. `docs/config.md`); при
+     `false` — required reviews не включай, чтобы владелец мог мержить
+     без апрувов.
 
 10. **Итог пользователю:** что создано; создан ли `adk.config.json` или
     существующий оставлен нетронутым (шаг 3); гейты уже активны (проверки

--- a/docs/config.md
+++ b/docs/config.md
@@ -74,6 +74,14 @@ CODEOWNERS) — без этого поле пустое даже при живо
 | `conventions.attribution` | bool | `true` | Trailer `Co-Authored-By` сегодня добавляется в коммиты по умолчанию (стандартное поведение агента), конфиг не отключает это неявно. |
 | `conventions.externalTitleLint` | bool | `false` | Отключает локальную валидацию заголовка PR (PostToolUse-хук `pr-title-check`, ADR-004) при `commitStyle=conventional` (issue #47, AC-5), если у проекта уже есть серверный линтер (commit-lint, PR-title-check) — переизобретать его не нужно (раздел «Границы» SPEC-002). Дефолт `false`: локальная валидация включена. |
 
+Серверный метод приземления GitHub — производная пары `conventions.squash`
+× `conventions.branchUpdate`, а не отдельный атрибут: `squash=true` →
+squash-merge; `false`+`rebase` → rebase-merge; `false`+`merge` →
+merge-commit (комбинация «rebase-актуализация + merge-commit приземление»
+невыразима сознательно — «Решённые вопросы» SPEC-002). Читатель печатает
+её командой `adk-config.sh --merge-method`; по этому выводу `/project-init`
+настраивает allowed merge methods нового репозитория (AC-6, issue #48).
+
 `conventions.commitStyle` энфорсится PostToolUse-хуком `pr-title-check`
 (ADR-004): после `gh pr create`/`gh pr edit` сверяется фактический
 заголовок PR, нарушение возвращается агенту с требованием исправить через

--- a/docs/specs/002-process-config.md
+++ b/docs/specs/002-process-config.md
@@ -157,7 +157,7 @@
       commitType, не соответствующим label'у issue; при `plain` и без
       конфига — не вмешивается. Валидируется состояние PR, а не текст
       команды (ADR-004: PreToolUse-парсинг shell-команд отклонён).
-- [ ] AC-6 (ждёт #48): `/project-init` в новом репозитории настраивает сервер по
+- [ ] AC-6: `/project-init` в новом репозитории настраивает сервер по
       конфигу: allowed merge method выводится из пары `squash` ×
       `branchUpdate` (true→squash-merge; false+rebase→rebase-merge;
       false+merge→merge-commit), плюс delete_branch_on_merge, protection,

--- a/hooks/scripts/adk-config.sh
+++ b/hooks/scripts/adk-config.sh
@@ -3,15 +3,20 @@
 # комментарий) для вызова из инструкций команд-markdown; хукам сам
 # lib/config.sh sourceable. Использование:
 #   adk-config.sh <путь.через.точку> [дефолт] [допустимые,значения,csv]
+#   adk-config.sh --merge-method   # производный метод приземления (AC-6)
 set -u
 
 path="${1:-}"
 if [ -z "$path" ]; then
-  echo "usage: adk-config.sh <path> [default] [allowed,values,csv]" >&2
+  echo "usage: adk-config.sh <path> [default] [allowed,values,csv] | adk-config.sh --merge-method" >&2
   exit 2
 fi
 default="${2:-}"
 allowed="${3:-}"
 
 . "$(cd "$(dirname "$0")" && pwd)/lib/config.sh"
-adk_config_get "$path" "$default" "$allowed"
+if [ "$path" = "--merge-method" ]; then
+  adk_config_merge_method
+else
+  adk_config_get "$path" "$default" "$allowed"
+fi

--- a/hooks/scripts/lib/config.sh
+++ b/hooks/scripts/lib/config.sh
@@ -39,6 +39,32 @@ adk_config_file() {
   fi
 }
 
+# Серверный метод приземления GitHub — производная пары conventions.squash ×
+# conventions.branchUpdate, не самостоятельная настройка (SPEC-002, AC-6):
+# squash=true → squash-merge; false+rebase → rebase-merge; false+merge →
+# merge-commit. Комбинация «rebase-актуализация + merge-commit приземление»
+# невыразима сознательно («Решённые вопросы» спеки). Сама производная —
+# чистая функция своих двух аргументов, отдельно от чтения конфига.
+adk_merge_method() { # adk_merge_method <squash: true|false> <branchUpdate: rebase|merge>
+  if [ "$1" = "true" ]; then
+    echo "squash-merge"
+  elif [ "$2" = "merge" ]; then
+    echo "merge-commit"
+  else
+    echo "rebase-merge"
+  fi
+}
+
+# Обёртка над конфигом: читает пару атрибутов (неизвестные значения
+# откатываются в дефолты с предупреждением adk_config_get в stderr) и
+# печатает производный метод.
+adk_config_merge_method() {
+  local squash branch_update
+  squash=$(adk_config_get "conventions.squash" "true" "true,false")
+  branch_update=$(adk_config_get "conventions.branchUpdate" "rebase" "rebase,merge")
+  adk_merge_method "$squash" "$branch_update"
+}
+
 adk_config_get() {
   local path="$1" default="${2:-}" allowed="${3:-}"
   local root cfg

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1884,6 +1884,58 @@ assert_exit "AC-1: templates/base/gitignore не игнорирует adk.config
 check_ac_doc AC-1 "README отражает adk.config.json в разделе /project-init" \
   "$KIT/README.md" "запишет плоские атрибуты процесса в \`adk.config.json\`"
 
+# ── Производный метод приземления и сервер нового репозитория (issue #48, AC-6) ─
+# SPEC-002: серверный метод приземления GitHub — производная пары
+# conventions.squash × conventions.branchUpdate, не самостоятельная
+# настройка: squash=true → squash-merge; false+rebase → rebase-merge;
+# false+merge → merge-commit. Комбинация «rebase-актуализация +
+# merge-commit приземление» невыразима сознательно («Решённые вопросы»).
+MMP="$TMP/mergemethod"
+mkdir -p "$MMP"
+
+check_merge_method() { # check_merge_method <описание> <ожидаемое>
+  local out
+  out=$(CLAUDE_PROJECT_DIR="$MMP" "$HOOKS/adk-config.sh" --merge-method 2>/dev/null)
+  if [ "$out" = "$2" ]; then
+    echo "PASS: $1"
+  else
+    echo "FAIL: $1 (вернулось '$out', ожидали '$2')"
+    fails=$((fails + 1))
+  fi
+}
+
+# branchUpdate=merge в фикстуре нарочно: squash=true главнее стиля ветки
+printf '{"conventions": {"squash": true, "branchUpdate": "merge"}}' > "$MMP/adk.config.json"
+CLAUDE_PROJECT_DIR="$MMP" "$HOOKS/adk-config.sh" --merge-method >/dev/null 2>&1
+assert_exit "AC-6: merge-method: вывод завершается успешно" 0 $?
+check_merge_method "AC-6: merge-method: squash=true → squash-merge (независимо от branchUpdate)" "squash-merge"
+
+printf '{"conventions": {"squash": false, "branchUpdate": "rebase"}}' > "$MMP/adk.config.json"
+check_merge_method "AC-6: merge-method: squash=false + branchUpdate=rebase → rebase-merge" "rebase-merge"
+
+printf '{"conventions": {"squash": false, "branchUpdate": "merge"}}' > "$MMP/adk.config.json"
+check_merge_method "AC-6: merge-method: squash=false + branchUpdate=merge → merge-commit" "merge-commit"
+
+# дефолты: squash=true, branchUpdate=rebase (docs/config.md) → squash-merge
+rm "$MMP/adk.config.json"
+check_merge_method "AC-6: merge-method: без конфига — дефолт squash-merge" "squash-merge"
+
+printf '{"conventions": {"squash": false}}' > "$MMP/adk.config.json"
+check_merge_method "AC-6: merge-method: squash=false без branchUpdate — дефолт rebase даёт rebase-merge" "rebase-merge"
+rm "$MMP/adk.config.json"
+
+# /project-init для нового репозитория применяет серверные настройки по конфигу
+check_ac_doc AC-6 "project-init.md выводит метод приземления через adk-config.sh --merge-method" \
+  "$PI_MD" "adk-config.sh --merge-method"
+check_ac_doc AC-6 "project-init.md применяет allowed merge methods по производному значению" \
+  "$PI_MD" "allow_squash_merge"
+check_ac_doc AC-6 "project-init.md включает delete_branch_on_merge" \
+  "$PI_MD" "delete_branch_on_merge=true"
+check_ac_doc AC-6 "project-init.md настраивает protection по policies (человеческий approve)" \
+  "$PI_MD" "required_pull_request_reviews"
+check_ac_doc AC-6 "README описывает производный метод приземления в серверном гейте" \
+  "$KIT/README.md" "метод приземления, производный от"
+
 # ── Итог ─────────────────────────────────────────────────────────────────────
 echo "─────"
 if [ "$fails" -eq 0 ]; then


### PR DESCRIPTION
Closes #48

## Что сделано

- `hooks/scripts/lib/config.sh`: `adk_merge_method` — чистая функция пары `conventions.squash` × `conventions.branchUpdate` (`true` → squash-merge; `false`+`rebase` → rebase-merge; `false`+`merge` → merge-commit) и обёртка `adk_config_merge_method`, читающая конфиг с валидацией enum-значений.
- `hooks/scripts/adk-config.sh`: режим `--merge-method` для вызова из инструкций команд.
- `commands/project-init.md`, шаг 9 (новый репозиторий): применение allowed merge methods по выводу `--merge-method` (ровно один `allow_*_merge=true`), `delete_branch_on_merge=true`, branch protection по `policies` — `required_pull_request_reviews` с `required_approving_review_count=1` при `policies.review.humanApprovalRequired=true`.
- README (раздел серверного гейта) и `docs/config.md`: описан производный метод приземления.
- Спека SPEC-002: аннотация `(ждёт #48)` снята с AC-6 (она указывала именно на #48; тесты AC-6 добавлены этим PR, части #49/#50 добавят свои).

## Тесты (tests/run.sh, тег AC-6)

- три фикстуры производной: `squash=true` (при `branchUpdate=merge` — приоритет squash) → `squash-merge`; `false`+`rebase` → `rebase-merge`; `false`+`merge` → `merge-commit`;
- дефолт без конфига → `squash-merge`; `squash=false` без `branchUpdate` → `rebase-merge`;
- док-проверки project-init.md (`--merge-method`, `allow_squash_merge`, `delete_branch_on_merge=true`, `required_pull_request_reviews`) и README.

`./scripts/check` и `./scripts/test` зелёные.

ADR не потребовался: правило производной задано самой спекой («Решённые вопросы» SPEC-002), реальных альтернатив не было.

🤖 Generated with [Claude Code](https://claude.com/claude-code)