### PR TITLE
Уточнить ассерт «в работе» в смоуке /stats до точной строки (#88)

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -544,7 +544,7 @@ stats_out=$(ADK_LOGS_DIR="$STATS_INPROGRESS_ONLY" "$HOOKS/adk-stats.sh" 2>&1)
 assert_exit "AC-3: adk-stats: каталог только с незавершённой задачей — exit 0" 0 $?
 assert_not_contains "AC-3: adk-stats: незавершённая-только задача не спутана с пустым журналом" "$stats_out" "Журнал пуст"
 assert_contains "AC-3: adk-stats: незавершённая задача показана как «в работе»" "$stats_out" "В работе"
-assert_contains "AC-3: adk-stats: количество задач в работе отражено в выводе" "$stats_out" "1"
+assert_contains "AC-3: adk-stats: количество задач в работе отражено в выводе" "$stats_out" "В работе (без итога): 1"
 
 # строка, оборванная посреди multibyte UTF-8 (типичный исход обрыва процесса
 # при записи в журнал) — не должна ронять скрипт UnicodeDecodeError-ом;


### PR DESCRIPTION
Closes #88

## Что сделано

`tests/run.sh:547` сверял вывод `adk-stats.sh` с голой подстрокой `"1"`, которая совпадает с любой единицей в выводе (дата, проценты, другие счётчики), а не именно со строкой про задачи «в работе». Заменил на сверку точной подстроки, которую реально печатает скрипт для этого фикстура.

## Репро (вручную, по DoD issue)

Фикстур `STATS_INPROGRESS_ONLY` (`tests/run.sh:537-547`) содержит только `issue-30.jsonl` с `start`+`review`, без `outcome` — это ветка `hooks/scripts/adk-stats.sh:131-141` (не строка 173, см. «Отступление от issue» ниже), и весь вывод скрипта для неё — одна строка: `Завершённых задач ещё нет: событие outcome не записано ни для одной задачи. В работе (без итога): 1.`

Демонстрация вакуумности: замутировал печать этой строки так, чтобы вывод содержал цифру `1`, но не отражал реальный счётчик задач в работе (`print(f"мусорный текст версии 1 без счётчика")` вместо оригинального `print(...)`, adk-stats.sh:138-141). Результат:
- старый ассерт `assert_contains ... "1"` — **PASS** (вакуумно, цифра `1` нашлась в постороннем тексте);
- новый ассерт `assert_contains ... "В работе (без итога): 1"` — **FAIL** (корректно ловит поломку).

(Буквальная мутация «убрать строку `В работе` целиком», предложенная в issue, для этого конкретного фикстура не демонстративна: единственная строка вывода при этом полностью исчезает вместе с единственной цифрой `1`, поэтому старый ассерт тоже падает — совпадение, а не вакуумность. Вакуумность реальна и проверяется мутацией выше, где цифра сохраняется, а смысл — нет.)

## Отступление от issue

Issue ссылалась как на эталон на `hooks/scripts/adk-stats.sh:173` (`"В работе (без итога, в агрегаты ниже не входят): N"`). Эта строка печатается только в ветке, где есть хотя бы одна завершённая задача (`tasks` непустой). Фикстур `STATS_INPROGRESS_ONLY` содержит только `issue-30` без `outcome` — не завершённую, а исключительно "в работе" задачу, поэтому код идёт по другой, более ранней ветке (`adk-stats.sh:138-141`), которая печатает другой текст: `"В работе (без итога): N."` (без хвоста «, в агрегаты ниже не входят»). Синхронизировал ассерт с реальной строкой, которую печатает именно эта ветка, а не с эталоном из issue — сохранив цель DoD (точная строка вместо вакуумной подстроки). Соседний ассерт для ветки со строкой 173 уже существует и корректен (`tests/run.sh:678`).

## Тесты

- `./scripts/check` — OK
- `./scripts/test` — все тесты зелёные
- Репро-мутация (см. выше) — подтверждена вручную: до фикса ассерт вакуумно проходит на мутанте с посторонней цифрой, после фикса — корректно ловит эту же мутацию