### PR TITLE
fix: branch protection в /project-init — 403, restrictions, default_branch (#90)

### DIFF
--- a/commands/project-init.md
+++ b/commands/project-init.md
@@ -180,17 +180,27 @@ argument-hint: "[путь к проекту; по умолчанию текущ�
      приземления удаляет сервер (`--delete-branch` в командах остаётся
      страховкой для репозиториев без этой настройки);
    - **branch protection согласно `policies`**: merge только через PR с
-     зелёным required-чеком `gates`, прямые пуши и force push в main
-     запрещены — `gh api -X PUT repos/{owner}/{repo}/branches/main/protection`
-     с `required_status_checks.contexts=["gates"]`,
-     `allow_force_pushes=false`, `enforce_admins=false`. Если
-     `adk-config.sh policies.review.humanApprovalRequired false` даёт
-     `true` — добавь `required_pull_request_reviews` с
+     зелёным required-чеком `gates`, прямые пуши и force push в дефолтную
+     ветку запрещены. Имя ветки не литерал `main` — узнай фактическое:
+     `gh api repos/{owner}/{repo} -q .default_branch`, и подставь его в URL —
+     `gh api -X PUT repos/{owner}/{repo}/branches/<default_branch>/protection`.
+     GitHub требует в теле запроса все четыре верхнеуровневых ключа сразу,
+     иначе отвечает `422`: `required_status_checks.contexts=["gates"]`,
+     `enforce_admins=false`, `required_pull_request_reviews` (см. ниже) и
+     `restrictions=null` (список пользователей/команд с персональным
+     разрешением на пуш мы не ограничиваем — ключ обязателен, но всегда
+     `null`); отдельным полем — `allow_force_pushes=false`, запрет force
+     push. Если `adk-config.sh policies.review.humanApprovalRequired
+     false` даёт `true` — `required_pull_request_reviews` равен объекту с
      `required_approving_review_count=1` (обязательный человеческий approve;
      заодно GitHub начнёт заполнять `reviewDecision`, на который опирается
      политика merge `human-review-required` — см. `docs/config.md`); при
-     `false` — required reviews не включай, чтобы владелец мог мержить
-     без апрувов.
+     `false` — `required_pull_request_reviews=null` (владелец мог мержить
+     без апрувов), ключ в теле всё равно присутствует. Ответ `403` на этот
+     вызов — не сбой инициализации, а факт: настройками защиты веток под
+     текущими правами не владеем (например, в организации без admin-доступа
+     к репозиторию) — назови это пользователю в итоговом отчёте (шаг 10) и
+     переходи дальше, не прерывая инициализацию.
 
    **Существующий репозиторий — только сверка, без изменений.** Принцип
    SPEC-002 «существующее не перезаписывается»: настройки читаются,
@@ -201,9 +211,12 @@ argument-hint: "[путь к проекту; по умолчанию текущ�
      `gh api repos/{owner}/{repo}` — allowed merge methods
      (`allow_squash_merge` / `allow_rebase_merge` / `allow_merge_commit`)
      и `delete_branch_on_merge`;
-     `gh api repos/{owner}/{repo}/branches/main/protection` — branch
-     protection (ответ 404 — protection не настроена: не сбой, а факт для
-     сверки); наличие файлов `.github/ISSUE_TEMPLATE/` по типам из
+     `gh api repos/{owner}/{repo}/branches/<default_branch>/protection`
+     (имя ветки — то же `default_branch`, что и для нового репозитория, не
+     литерал `main`) — branch protection: ответ 404 — protection не
+     настроена, ответ 403 — под текущими правами доступа к настройкам
+     защиты нет (не admin репозитория); оба ответа — не сбой инициализации,
+     а факт для сверки; наличие файлов `.github/ISSUE_TEMPLATE/` по типам из
      `types.*`;
    - ожидаемое вычисли по конфигу тем же способом, что и для нового
      репозитория: метод приземления — `adk-config.sh --merge-method`,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2008,6 +2008,27 @@ check_ac_doc AC-6 "project-init.md настраивает protection по polici
 check_ac_doc AC-6 "README описывает производный метод приземления в серверном гейте" \
   "$KIT/README.md" "метод приземления, производный от"
 
+# ── /project-init: branch protection — 403, restrictions, дефолтная ветка
+# (issue #90, хвост вердиктов ревью PR #63 и PR #65). Три факта из DoD:
+# 403 назван наравне с 404 как факт (не сбой инициализации), restrictions:
+# null в PUT (GitHub иначе отвечает 422 без всех четырёх верхнеуровневых
+# ключей), имя ветки берётся из default_branch в обоих вызовах — не
+# зашито литералом main.
+check_ac_doc "issue #90" "project-init.md: PUT branch protection несёт restrictions: null" \
+  "$PI_MD" "restrictions=null"
+check_ac_doc "issue #90" "project-init.md: PUT branch protection берёт ветку из default_branch, не из литерала main" \
+  "$PI_MD" "gh api repos/{owner}/{repo} -q .default_branch"
+check_ac_doc "issue #90" "project-init.md: PUT branch protection адресуется по <default_branch>, не по main" \
+  "$PI_MD" "gh api -X PUT repos/{owner}/{repo}/branches/<default_branch>/protection"
+check_ac_doc "issue #90" "project-init.md: 403 на PUT branch protection назван фактом, не сбоем инициализации" \
+  "$PI_MD" "Ответ \`403\` на этот вызов — не сбой инициализации"
+check_ac_doc "issue #90" "project-init.md: сверка существующего репозитория читает branch protection по default_branch" \
+  "$PI_MD" "gh api repos/{owner}/{repo}/branches/<default_branch>/protection"
+check_ac_doc "issue #90" "project-init.md: сверка существующего репозитория называет 403 фактом наравне с 404" \
+  "$PI_MD" "ответ 403 — под текущими правами доступа к настройкам"
+assert_not_contains "issue #90: старая форма — PUT протекции литералом branches/main/protection не матчится" \
+  "$project_init_content" 'branches/main/protection'
+
 # ── /project-init генерирует ISSUE_TEMPLATE из блока types (issue #49, AC-6) ─
 # SPEC-002: .github/ISSUE_TEMPLATE/* генерируются из types при /project-init —
 # люди в команде создают issues в том же формате, что и агенты; иначе /work,


### PR DESCRIPTION
Closes #90

## Что сделано

`commands/project-init.md`, шаг 9 (branch protection):

- PUT `branches/{branch}/protection` теперь несёт все четыре обязательных верхнеуровневых ключа, включая `restrictions=null` (без него GitHub отвечает 422).
- Имя ветки в обоих API-вызовах (PUT для нового репозитория, GET сверки для существующего) берётся динамически — `gh api repos/{owner}/{repo} -q .default_branch`, а не зашито литералом `main`.
- Ответ `403` назван фактом наравне с `404` (не сбой инициализации, а «настройками защиты веток под текущими правами не владеем») — в обеих ветках: при попытке применить protection к новому репозиторию и при сверке существующего.

Хвост вердиктов ревью PR #63 и PR #65 (K3 инвентаризации `/consolidate`).

## Тесты

`tests/run.sh` — блок `issue #90` (7 doc-тестов): restrictions:null в PUT, ветка из default_branch в обоих вызовах, 403 назван в обеих ветках, старая форма `branches/main/protection` литералом больше не матчится. Плюс существующий AC-6 тест на 404 сохранён без изменений (текст 404 остался прежним, только добавлено соседнее упоминание 403).

`./scripts/check` и `./scripts/test` — зелёные.