### PR TITLE
refactor: свести чтение labels issue к adk_gh_issue_fields по образцу adk_gh_pr_fields (#92)

### DIFF
--- a/hooks/scripts/lib/paths.sh
+++ b/hooks/scripts/lib/paths.sh
@@ -95,3 +95,28 @@ adk_gh_pr_fields() {
   fi
   printf '%s\n' "$out"
 }
+
+# adk_gh_issue_fields <issue> <repo_flag> <git_root> <json-поля> <jq-выражение> —
+# один вызов `gh issue view` за нужные поля issue. Фолбэки — та же пара, что у
+# adk_gh_pr_fields (-R из команды → git-корень команды), и то же отсутствие
+# переключения между ветками: если указан -R и запрос по нему не удался,
+# на git-корень команды это не откатывается — issue #N чужого репозитория
+# нельзя искать в локальном по догадке, это дало бы labels другого issue и
+# ложный вердикт (см. pr-title-check.sh, сверка commitType issue с label).
+# Отличие от adk_gh_pr_fields: код возврата функции — это rc самого `gh`
+# (не всегда 0), а не только пустая строка на выходе. Вызывающему важно
+# различать «gh отработал, но нужных полей нет» (например, issue без единого
+# label — легитимный пустой результат, rc=0) от «прочитать не удалось» (gh
+# недоступен или issue не найден, rc≠0); adk_gh_pr_fields такое различие не
+# даёт, потому что его вызывающим оно не нужно — формат ответа
+# `\(.number) \(.title)` уже отличает пустой результат от данных по форме.
+adk_gh_issue_fields() {
+  local issue="$1" repo_flag="$2" git_root="$3" json_fields="$4" jq_q="$5" out="" rc=1
+  if [ -n "$repo_flag" ]; then
+    out=$(gh issue view "$issue" -R "$repo_flag" --json "$json_fields" -q "$jq_q" 2>/dev/null); rc=$?
+  elif [ -n "$git_root" ]; then
+    out=$(cd "$git_root" && gh issue view "$issue" --json "$json_fields" -q "$jq_q" 2>/dev/null); rc=$?
+  fi
+  printf '%s\n' "$out"
+  return $rc
+}

--- a/hooks/scripts/pr-title-check.sh
+++ b/hooks/scripts/pr-title-check.sh
@@ -126,20 +126,17 @@ case "$verdict" in
     fix_required "Заголовок PR не соответствует конвенции: conventions.commitStyle=conventional требует формат «<commitType>[(scope)]: <суть> (#N)», где commitType — один из: ${verdict#format }. Сейчас: «$title». Исправь: gh pr edit $pr_ref$r_flag --title \"<commitType>: <суть> (#N)\" (scope — опционально)." ;;
 esac
 
-# Labels issue: env-обход → -R из команды (без отката на локальный
-# репозиторий: issue #N чужого repo нельзя искать в локальном — labels
-# другого issue дали бы ложный mismatch) → репозиторий команды.
-# Недоступность = сверка с label пропускается (формат уже проверен).
+# Labels issue: env-обход → adk_gh_issue_fields (-R из команды → git-корень
+# команды, без отката на локальный репозиторий при явном -R — issue #N
+# чужого repo нельзя искать в локальном, labels другого issue дали бы
+# ложный mismatch — см. комментарий у adk_gh_issue_fields в lib/paths.sh).
+# Код возврата функции различает «issue без labels» (rc=0, пустой список →
+# ниже трактуется как task) от «прочитать не удалось» (rc≠0 → unavailable,
+# сверка с label пропускается — формат уже проверен). Перевод в CSV
+# остаётся здесь же, в хуке.
 if [ -n "${ADK_GUARD_ISSUE_LABELS+x}" ]; then
   labels="$ADK_GUARD_ISSUE_LABELS"
-elif [ -n "$repo_flag" ]; then
-  if labels_raw=$(gh issue view "$issue_n" -R "$repo_flag" --json labels -q '.labels[].name' 2>/dev/null); then
-    labels=$(printf '%s' "$labels_raw" | tr '\n' ',')
-  else
-    labels="unavailable"
-  fi
-elif [ -n "$git_root" ] \
-  && labels_raw=$(cd "$git_root" && gh issue view "$issue_n" --json labels -q '.labels[].name' 2>/dev/null); then
+elif labels_raw=$(adk_gh_issue_fields "$issue_n" "$repo_flag" "$git_root" labels '.labels[].name'); then
   labels=$(printf '%s' "$labels_raw" | tr '\n' ',')
 else
   labels="unavailable"


### PR DESCRIPTION
Closes #92

## Что сделано

- `hooks/scripts/lib/paths.sh`: добавлен `adk_gh_issue_fields <issue> <repo_flag> <git_root> <json-поля> <jq-выражение>` — по образцу `adk_gh_pr_fields`, с той же парой фолбэков (-R из команды → git-корень команды, без переключения между ними). Намеренное отличие от `adk_gh_pr_fields` зафиксировано комментарием: код возврата функции — это rc самого `gh`, а не всегда 0, потому что вызывающему (`pr-title-check.sh`) важно различать «issue без нужных labels» (легитимный пустой результат, rc=0 → трактуется как task) от «прочитать не удалось» (rc≠0 → сверка пропускается).
- `hooks/scripts/pr-title-check.sh`: инлайновый каскад чтения labels issue (строки 133-146) заменён вызовом хелпера; env-обход (`ADK_GUARD_ISSUE_LABELS`) и перевод в CSV (`tr '\n' ','`) остались в хуке, как до правки.

## Чем доказано

Рефакторинг: наблюдаемое поведение не меняется, существующие тесты (`tests/run.sh`) зелёные без правок ассертов. Дополнительно `adk_gh_issue_fields` проверен вручную заглушкой `gh` на все четыре случая (нет ни -R, ни git-корня; git-корень + gh успешен, но пусто; git-корень + gh недоступен; -R успешен) — rc и вывод совпадают с поведением до правки.

`./scripts/check` и `./scripts/test` — зелёные.

## ADR

Новых ADR нет: отличие в поведении хелпера (rc функции вместо всегда 0) — небольшое, дёшево развернуть назад и полностью объяснено комментарием в коде рядом с определением функции; отдельного документа не требует (скилл adr: «сомневаешься — не пиши»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>