### PR TITLE
refactor: свести три копии find_clean в шаблоне swift-ios к lib.sh (#95)

### DIFF
--- a/templates/swift-ios/scripts/check
+++ b/templates/swift-ios/scripts/check
@@ -3,16 +3,9 @@
 # (тулчейн Xcode 16+: линт и формат — swift format из его состава, ноль внешних
 # установок; SwiftLint/SwiftFormat сознательно не используются — ADR-005).
 set -eo pipefail
-cd "$(dirname "$0")/.."
-
-# Файлы проекта по имени, без артефактов сборки и зависимостей.
-find_clean() {
-  find . -name "$1" \
-    -not -path '*/.build/*' \
-    -not -path '*/DerivedData/*' \
-    -not -path '*/Pods/*' \
-    -not -path '*/.git/*'
-}
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+source "$script_dir/lib.sh"
+cd "$script_dir/.."
 
 # Ближайший родительский SPM-пакет файла (пусто — файл вне пакетов).
 package_of() {

--- a/templates/swift-ios/scripts/fix
+++ b/templates/swift-ios/scripts/fix
@@ -2,15 +2,9 @@
 # Контракт agent-dev-kit: автоформат. Молча правит что может;
 # оставшееся — забота scripts/check.
 set -eo pipefail
-cd "$(dirname "$0")/.."
-
-sources() {
-  find . -name '*.swift' \
-    -not -path '*/.build/*' \
-    -not -path '*/DerivedData/*' \
-    -not -path '*/Pods/*' \
-    -not -path '*/.git/*'
-}
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+source "$script_dir/lib.sh"
+cd "$script_dir/.."
 
 targets=()
 if [ $# -gt 0 ]; then
@@ -20,7 +14,7 @@ if [ $# -gt 0 ]; then
     esac
   done
 else
-  while IFS= read -r f; do targets+=("$f"); done < <(sources)
+  while IFS= read -r f; do targets+=("$f"); done < <(find_clean '*.swift')
 fi
 
 [ ${#targets[@]} -gt 0 ] || exit 0

--- a/templates/swift-ios/scripts/lib.sh
+++ b/templates/swift-ios/scripts/lib.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Общие хелперы контрактных скриптов шаблона swift-ios (check/fix/test).
+# Подключается через `source`, не исполняется напрямую.
+
+# Файлы проекта по имени, без артефактов сборки и зависимостей.
+find_clean() {
+  find . -name "$1" \
+    -not -path '*/.build/*' \
+    -not -path '*/DerivedData/*' \
+    -not -path '*/Pods/*' \
+    -not -path '*/.git/*'
+}

--- a/templates/swift-ios/scripts/test
+++ b/templates/swift-ios/scripts/test
@@ -4,7 +4,9 @@
 # не запускает — ограничение названо в ADR-006; проект с такими таргетами
 # расширяет этот скрипт по месту (xcodebuild test).
 set -eo pipefail
-cd "$(dirname "$0")/.."
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+source "$script_dir/lib.sh"
+cd "$script_dir/.."
 
 # Тесты каждого SPM-пакета. «Пустой набор тестов — не провал» (контракт):
 # swift test на пакете без тест-таргетов сам падает с «no tests found» —
@@ -20,11 +22,7 @@ while IFS= read -r pkg; do
       *) exit 1 ;;
     esac
   fi
-done < <(find . -name Package.swift \
-  -not -path '*/.build/*' \
-  -not -path '*/DerivedData/*' \
-  -not -path '*/Pods/*' \
-  -not -path '*/.git/*')
+done < <(find_clean 'Package.swift')
 
 # Smoke «приложение собирается» — аналог bootstrap-теста сервиса из
 # docs/contract.md: тесты пакетов не трогают таргеты приложения и не поймают


### PR DESCRIPTION
Closes #95

## Что сделано
Набор исключений (`.build`, `DerivedData`, `Pods`, `.git`) был выписан трижды в `templates/swift-ios/scripts/{check,fix,test}` — два одинаковых тела под разными именами (`find_clean`/`sources`), третье инлайном. Вынес общую функцию `find_clean` в новый `templates/swift-ios/scripts/lib.sh`, который все три скрипта подключают через `source` (до `cd` в корень проекта, чтобы путь к lib.sh был известен заранее).

- `check` и `test` теперь зовут `find_clean` из lib.sh вместо локальной копии.
- `fix` — убрал алиас `sources()`, зовёт `find_clean '*.swift'` напрямую (то же имя, что в check/test).
- Поведение гейтов не менялось: набор исключений и семантика функции идентичны исходным.

## Тесты
Рефакторинг (тип `consolidate`) — поведение не меняется, новых тестов не требуется по DoD. Подтверждение:
- `./scripts/check` — зелёный.
- `./scripts/test` — зелёный, 452/452 ассертов, вывод побайтово идентичен прогону до изменений (включая все AC issue #70 для swift-ios: голый проект, падающие/пустые тесты пакета, check по файлу пакета/вне пакетов, project.yml без xcodegen, шум xcodebuild -list).
- Дополнительно вручную проверил `scripts/fix` на временном проекте — подхватывает `.swift`-файлы вне `.build/`, `.build/` исключается корректно.

Никаких ADR — решение (общий `lib.sh`, подключаемый через `source`) прямое и не имеет альтернатив, требующих фиксации.