### PR TITLE
Поправить диагностику: label create, тег AC-8, буферизация swift test (#99)

### DIFF
--- a/commands/plan.md
+++ b/commands/plan.md
@@ -24,10 +24,14 @@ argument-hint: "[номер или путь спеки; по умолчанию 
    - label типа задачи: имя возьми из конфига проекта —
      `${CLAUDE_PLUGIN_ROOT}/hooks/scripts/adk-config.sh types.task.label type:task`
      (отсутствие конфига или атрибута = дефолт `type:task`, см.
-     docs/config.md). Перед созданием issues создай отсутствующий label
-     в репозитории: `gh label create <label> 2>/dev/null || true`.
-     Правило спеки: тип задачи задаётся только label'ом, из текста issue
-     не выводится;
+     docs/config.md). Перед созданием issues создай отсутствующий label в
+     репозитории: `label_err=$(gh label create <label> 2>&1 >/dev/null)`.
+     Раздели исходы: нулевой exit или текст ошибки с «already exists» —
+     успех (label уже есть, идемпотентно), молча продолжай к issues; любую
+     другую ошибку (например, отказ по правам) не глуши — скажи явно, что
+     label не создан и `gh issue create --label` может упасть, и покажи
+     текст ошибки. Правило спеки: тип задачи задаётся только label'ом, из
+     текста issue не выводится;
    - по issue на задачу: заголовок — название задачи, тело — контекст,
      «Сделать», DoD, зависимости («Blocked by #N»), ссылка на файл спеки;
      `gh issue create --milestone ... --label <label> --title ... --body ...`;

--- a/templates/swift-ios/scripts/test
+++ b/templates/swift-ios/scripts/test
@@ -11,17 +11,22 @@ cd "$script_dir/.."
 # Тесты каждого SPM-пакета. «Пустой набор тестов — не провал» (контракт):
 # swift test на пакете без тест-таргетов сам падает с «no tests found» —
 # этот и только этот провал считается успехом.
+# Вывод стримится через tee (не копится в переменной) — разработчик видит
+# прогресс `swift test` по мере выполнения, а не всё разом после завершения
+# пакета; решение гейта (pass/fail) по-прежнему разбирает содержимое
+# полного вывода, сохранённого во временный файл.
 while IFS= read -r pkg; do
   dir=$(dirname "$pkg")
-  if out=$(swift test --package-path "$dir" 2>&1); then
-    printf '%s\n' "$out"
+  out_file=$(mktemp)
+  if swift test --package-path "$dir" 2>&1 | tee "$out_file"; then
+    :
   else
-    printf '%s\n' "$out"
-    case "$out" in
+    case "$(cat "$out_file")" in
       *"no tests found"*) ;;
-      *) exit 1 ;;
+      *) rm -f "$out_file"; exit 1 ;;
     esac
   fi
+  rm -f "$out_file"
 done < <(find_clean 'Package.swift')
 
 # Smoke «приложение собирается» — аналог bootstrap-теста сервиса из

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -860,7 +860,7 @@ assert_contains "AC-8: autopilot.md ссылается на каноническ
 # AC-8 называет /autopilot поимённо: способ актуализации остаётся привязан к
 # conventions.branchUpdate и в нём — якорь на текст, чтение конфига — в каноне
 assert_contains "AC-8: autopilot.md актуализирует способом из conventions.branchUpdate" "$autopilot_step3" 'conventions\.branchUpdate'
-assert_not_contains "AC-8: autopilot.md не дублирует канон (чтение branchUpdate из конфига)" "$autopilot_step3" 'conventions\.branchUpdate rebase rebase,merge'
+assert_not_contains "K19 (issue #99): анти-дубль — autopilot.md не дублирует канон (чтение branchUpdate из конфига)" "$autopilot_step3" 'conventions\.branchUpdate rebase rebase,merge'
 check_ac_doc AC-8 "work.md: после актуализации гейты перегоняются обязательно, ready без перегона запрещён" \
   "$KIT/commands/work.md" "переводить PR в ready без перегона гейтов после актуализации запрещено"
 check_ac_doc AC-8 "autopilot.md: после актуализации гейты перегоняются обязательно, merge без перегона запрещён" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1068,8 +1068,12 @@ plan_step3=$(md_section "$PLANMD" '^3\. \*\*' '^4\. \*\*')
 
 assert_contains "AC-4: plan.md шаг 3 читает имя label типа task из конфига через adk-config.sh (дефолт type:task)" \
   "$plan_step3" 'adk-config\.sh types\.task\.label type:task'
-assert_contains "AC-4: plan.md шаг 3 создаёт отсутствующий label в репо идемпотентно (gh label create, ошибка «уже есть» гасится)" \
-  "$plan_step3" 'gh label create.*2>/dev/null'
+assert_contains "AC-4: plan.md шаг 3 перехватывает stderr gh label create, чтобы разобрать исход (не глушит его 2>/dev/null)" \
+  "$plan_step3" 'gh label create.*2>&1'
+assert_contains "AC-4: plan.md шаг 3 считает успехом идемпотентный случай «label уже есть» (already exists)" \
+  "$plan_step3" 'already exists'
+assert_contains "K18 (issue #99): plan.md шаг 3 не глушит прочие ошибки gh label create — говорит явно, что label не создан" \
+  "$plan_step3" 'label не создан'
 assert_contains "AC-4: plan.md шаг 3 создаёт label до создания issues" \
   "$plan_step3" 'gh label create.*gh issue create'
 assert_contains "AC-4: plan.md шаг 3 проставляет label создаваемым issues (--label в gh issue create)" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1491,6 +1491,7 @@ case "$1" in
     case "${SWIFT_STUB_TEST_MODE:-pass}" in
       notests) echo "error: no tests found; create a target in the 'Tests' directory"; exit 1 ;;
       fail) echo "Test Case 'X' failed"; exit 1 ;;
+      slow) echo "SLOW_MARKER_1"; sleep 1; echo "SLOW_MARKER_2"; exit 0 ;;
       *) exit 0 ;;
     esac ;;
   build)
@@ -1522,6 +1523,24 @@ assert_contains "issue #70: swift-ios: вывод упавших тестов д
 # пакет без тест-таргетов: «no tests found» — не провал (контракт)
 (cd "$SIOS" && PATH="$SPATH" SWIFT_STUB_TEST_MODE=notests ./scripts/test >/dev/null 2>&1)
 assert_exit "issue #70: swift-ios: «no tests found» пакета — не провал, exit 0" 0 $?
+
+# K20 (issue #99): вывод swift test стримится (tee), а не копится в переменной
+# до завершения пакета — проверяем, что первая строка появляется в выводе,
+# пока процесс ещё жив (до того как стаб допишет вторую строку).
+sios_stream_out="$TMP/swiftios-stream.log"
+(cd "$SIOS" && PATH="$SPATH" SWIFT_STUB_TEST_MODE=slow ./scripts/test >"$sios_stream_out" 2>&1) &
+stream_pid=$!
+sleep 0.4
+stream_still_running="no"
+kill -0 "$stream_pid" 2>/dev/null && stream_still_running="yes"
+stream_partial=$(cat "$sios_stream_out" 2>/dev/null)
+wait "$stream_pid"
+assert_contains "K20 (issue #99): swift-ios scripts/test — замер сделан пока swift test ещё выполняется (проверка валидна)" \
+  "$stream_still_running" "yes"
+assert_contains "K20 (issue #99): swift-ios scripts/test стримит первую строку вывода swift test раньше завершения пакета (tee, не накопление в переменной)" \
+  "$stream_partial" "SLOW_MARKER_1"
+assert_not_contains "K20 (issue #99): swift-ios scripts/test — вторая строка вывода ещё не записана в момент замера" \
+  "$stream_partial" "SLOW_MARKER_2"
 
 # check по файлу пакета собирает этот пакет — ошибка типов ловится
 # PostToolUse-гейтом, а не только полным прогоном (круг 1 PR #71)


### PR DESCRIPTION
Closes #99

## Что сделано

- **K18** (`commands/plan.md:28`): `gh label create <label> 2>/dev/null || true` разделено на исходы — успех это нулевой exit или текст ошибки с «already exists» (идемпотентно), любая другая ошибка (например, отказ по правам) не глушится, а явно сообщается вместе с текстом ошибки.
- **K19** (`tests/run.sh:863`): с анти-дубль-ассерта `autopilot.md не дублирует канон` снят тег `AC-8` — он проверял организацию документации, а не поведение критерия приёмки, и давал ложный вес в AC-трассировке. Сам гейт не изменился; AC-8 остаётся покрытым другими ассертами того же блока. `ac-check.sh --complete .` проходит.
- **K20** (`templates/swift-ios/scripts/test:14-17`): вывод `swift test` больше не копится в переменной целиком, а стримится через `tee` во временный файл; решение гейта (pass/fail по содержимому «no tests found») не изменилось.

## Тесты

- `tests/run.sh`: обновлены и добавлены ассерты для всех трёх правок (теги `K18 (issue #99)`, `K19 (issue #99)`, `K20 (issue #99)` — искал по ним в выводе `./scripts/test`).
- Для K20 добавлен «медленный» режим стаба `swift test` (`SWIFT_STUB_TEST_MODE=slow`), тест проверяет, что первая строка вывода появляется в файле, пока процесс ещё жив, а не только после завершения.
- `./scripts/check` и `./scripts/test` зелёные; `ac-check.sh --complete .` зелёный.

Изменения ограничены диагностикой/трассировкой — решения гейтов не менялись.
