### PR TITLE
Переставить счёт отставания перед checkout в шаге 3 /autopilot, сократить пересказ канона (#97)

### DIFF
--- a/commands/autopilot.md
+++ b/commands/autopilot.md
@@ -79,26 +79,26 @@ docs/adr/001-journal-event-schema.md; журнал — наблюдаемост�
    `type` — тип задачи по label issue, правило определения — шаг 1
    `/work`, оно здесь не дублируется).
    - **PR ready, `canMerge=true`** → сперва проверь актуальность ветки.
-     Канонический рецепт — шаг 6 `/work` (AC-8 SPEC-002); здесь — только
-     отличия автопилота от канона:
-     - **счёт отставания и конфликтность**: HEAD в этот момент — не ветка
-       PR (субагент шага 2 оставляет дерево на своей ветке), поэтому бери
-       оба факта явно, одним вызовом: `git fetch origin && gh pr view
-       <PR> --json mergeable,headRefName` — `CONFLICTING` — конфликт с
-       main (как в каноне), `UNKNOWN` — GitHub ещё считает mergeability,
-       повтори запрос; отставание — `git rev-list --count origin/<ветка
-       PR>..origin/main` (счётчик больше нуля значит BEHIND, ветка
-       отстала), `<ветка PR>` — то же поле `headRefName`;
+     Канонический рецепт — шаг 6 `/work` (AC-8 SPEC-002): способ
+     актуализации — `conventions.branchUpdate`, обязательный перегон
+     гейтов — merge без перегона гейтов после актуализации запрещён;
+     здесь — только отличия автопилота от канона:
+     - **счёт отставания и конфликтность**: checkout дерева в этот момент
+       не определён (субагент шага 2 оставляет дерево на своей ветке, на
+       main его возвращает лишь merge с `--delete-branch`), поэтому бери
+       оба факта явно, не от HEAD: конфликтность и ветка PR — одним
+       вызовом `gh pr view <PR> --json mergeable,headRefName`
+       (`CONFLICTING` — конфликт с main, как в каноне; `UNKNOWN` —
+       повтори запрос); отставание — `git fetch origin && git rev-list
+       --count origin/<ветка PR>..origin/main` (счётчик больше нуля
+       значит BEHIND, ветка отстала), `<ветка PR>` — то же поле
+       `headRefName`;
      - **checkout**: актуализируй отставшую ветку PR только в явном
-       `gh pr checkout <PR>` — текущий checkout дерева в этот момент не
-       определён (субагент шага 2 оставляет дерево на своей ветке, на
-       main его возвращает лишь merge с `--delete-branch`); способ
-       актуализации — `conventions.branchUpdate`, как в каноне;
-     - **push**: только после локально зелёных гейтов, как в каноне —
-       merge без перегона гейтов после актуализации запрещён; refspec
-       обязателен (`git push --force-with-lease origin <ветка PR>` после
-       rebase, `git push origin <ветка PR>` после merge) — push с
-       force-флагом без него применился бы к текущему checkout;
+       `gh pr checkout <PR>`;
+     - **push**: refspec обязателен (`git push --force-with-lease origin
+       <ветка PR>` после rebase, `git push origin <ветка PR>` после
+       merge) — push с force-флагом без него применился бы к текущему
+       checkout;
      - **исход отказа — застревание, а не вопрос человеку**: конфликт с
        main требует человека, но останавливается не прогон, а задача —
        метка needs-human, уведомление, `result=stuck reason="конфликт с

--- a/commands/autopilot.md
+++ b/commands/autopilot.md
@@ -78,28 +78,27 @@ docs/adr/001-journal-event-schema.md; журнал — наблюдаемост�
    содержит пробелы — заключай в кавычки, как `reason` в шаге 7 `/work`;
    `type` — тип задачи по label issue, правило определения — шаг 1
    `/work`, оно здесь не дублируется).
-   - **PR ready, `canMerge=true`** → сперва проверь актуальность ветки
-     (AC-8 SPEC-002). Канонический рецепт — шаг 6 `/work`: отставание
-     фактом из git, конфликтность через `gh pr view <PR> --json
-     mergeable` (`CONFLICTING` — человек, `UNKNOWN` — повтори запрос),
-     способ актуализации из `conventions.branchUpdate`, обязательный
-     перегон гейтов (`./scripts/check`, `./scripts/test`) после неё —
-     merge без перегона гейтов после актуализации запрещён, зелёные
-     проверки отставшей ветки относятся к устаревшему состоянию кода.
-     Здесь — только отличия автопилота от канона:
-     - **checkout**: актуализируй ветку PR только в явном
+   - **PR ready, `canMerge=true`** → сперва проверь актуальность ветки.
+     Канонический рецепт — шаг 6 `/work` (AC-8 SPEC-002); здесь — только
+     отличия автопилота от канона:
+     - **счёт отставания и конфликтность**: HEAD в этот момент — не ветка
+       PR (субагент шага 2 оставляет дерево на своей ветке), поэтому бери
+       оба факта явно, одним вызовом: `git fetch origin && gh pr view
+       <PR> --json mergeable,headRefName` — `CONFLICTING` — конфликт с
+       main (как в каноне), `UNKNOWN` — GitHub ещё считает mergeability,
+       повтори запрос; отставание — `git rev-list --count origin/<ветка
+       PR>..origin/main` (счётчик больше нуля значит BEHIND, ветка
+       отстала), `<ветка PR>` — то же поле `headRefName`;
+     - **checkout**: актуализируй отставшую ветку PR только в явном
        `gh pr checkout <PR>` — текущий checkout дерева в этот момент не
        определён (субагент шага 2 оставляет дерево на своей ветке, на
-       main его возвращает лишь merge с `--delete-branch`);
-     - **счёт отставания**: до этого checkout HEAD — не ветка PR, поэтому
-       считай от неё явно: `git fetch origin && git rev-list --count
-       origin/<ветка PR>..origin/main` (счётчик больше нуля значит
-       BEHIND, ветка отстала); `<ветка PR>` бери из того же
-       `gh pr view <PR> --json mergeable,headRefName`;
-     - **push**: refspec обязателен (`git push --force-with-lease origin
-       <ветка PR>` после rebase, `git push origin <ветка PR>` после
-       merge) — push с force-флагом без него применился бы к текущему
-       checkout;
+       main его возвращает лишь merge с `--delete-branch`); способ
+       актуализации — `conventions.branchUpdate`, как в каноне;
+     - **push**: только после локально зелёных гейтов, как в каноне —
+       merge без перегона гейтов после актуализации запрещён; refspec
+       обязателен (`git push --force-with-lease origin <ветка PR>` после
+       rebase, `git push origin <ветка PR>` после merge) — push с
+       force-флагом без него применился бы к текущему checkout;
      - **исход отказа — застревание, а не вопрос человеку**: конфликт с
        main требует человека, но останавливается не прогон, а задача —
        метка needs-human, уведомление, `result=stuck reason="конфликт с


### PR DESCRIPTION
Closes #97

## Что сделано

Кандидат K12 инвентаризации `/consolidate` (веха consolidation), разблокирован issue #80.

1. **Порядок пунктов**: читалось «встань на ветку PR → посчитай отставание», хотя счёт идёт от `origin/<ветка PR>..origin/main` и checkout для него не нужен — checkout требуется только уже отставшей ветке. Переставлено: счёт отставания и конфликтность → checkout → push.
2. **Вводный абзац** пересказывал канон целиком (источник факта отставания, детали проверки `mergeable`, чтение `conventions.branchUpdate`, обоснование обязательного перегона гейтов) — оставался второй копией рецепта, расходящейся с шагом 6 `/work`. Сокращён до факта канона (AC-8 SPEC-002, `conventions.branchUpdate`, обязательность перегона гейтов — коротко, честно как факты канона, не как «отличия») плюс перечня отличий автопилота ниже.
3. **`gh pr view <PR> --json mergeable`** был описан дважды (в интро и в пункте «счёт отставания», с разным набором полей) — сведён к одному объединённому вызову с `mergeable,headRefName`.

Защищённый якорь «merge без перегона гейтов после актуализации запрещён» (issue явно требует его не терять) сохранён — во вводной фразе шага 3, вместе с `conventions.branchUpdate`, как факт канона; удалена только более полная рационале-фраза («зелёные проверки отставшей ветки относятся к устаревшему состоянию кода»), дословно дублировавшая канон.

Круг 1 ревью поймал две мои собственные регрессии при сокращении (новый дословный дубль про `UNKNOWN`, продублированный дважды парентезис про субагента, логическое противоречие «HEAD — не ветка PR» vs «checkout не определён») — исправлены; круг 2 подтвердил APPROVE.

## Тесты

Тип задачи — `consolidate`: поведение инструкции не менялось (те же факты собираются, те же действия в том же порядке результатов — проверено кругом 2 сравнением с main), существующие тесты не редактировались (`tests/run.sh` не тронут вовсе). Все AC-8 якоря для `autopilot_step3` проверены по реальным assert-вызовам в tests/run.sh (не по тексту issue) — все на месте.

`./scripts/check` и `./scripts/test` зелёные (480 PASS, идентично main).