### PR TITLE
Вывести флаг merge из --merge-method вместо жёсткого --squash (#77)

### DIFF
--- a/commands/autopilot.md
+++ b/commands/autopilot.md
@@ -113,11 +113,14 @@ docs/adr/001-journal-event-schema.md; журнал — наблюдаемост�
        (`git checkout main`) — дерево не бросай в rebase-in-progress и не
        оставляй на ветке PR.
 
-     Ветка актуальна и гейты зелёные — `gh pr merge <PR> --squash
-     --delete-branch` (squash: один issue = один коммит в main,
-     заголовок PR становится сообщением коммита); если настроен CI —
-     дождись зелёного перед merge (`gh pr checks --watch`; это же
-     покрывает CI-прогон актуализированной ветки); после
+     Ветка актуальна и гейты зелёные — флаг слияния выводится из метода
+     приземления (`${CLAUDE_PLUGIN_ROOT}/hooks/scripts/adk-config.sh
+     --merge-method`), а не зашит жёстко: `squash-merge` → `--squash`,
+     `rebase-merge` → `--rebase`, `merge-commit` → `--merge`; `gh pr merge
+     <PR> <флаг> --delete-branch` (при дефолтном squash-merge — один issue
+     = один коммит в main, заголовок PR становится сообщением коммита);
+     если настроен CI — дождись зелёного перед merge (`gh pr checks
+     --watch`; это же покрывает CI-прогон актуализированной ветки); после
      merge — залогируй `result=merged`, следующая итерация;
    - **PR ready, но merge не твой** — `canMerge=false` либо merge
      заблокировал хук по `policies.merge` → PR не мержи, добавь его в

--- a/commands/work.md
+++ b/commands/work.md
@@ -60,8 +60,10 @@ argument-hint: "[номер issue; по умолчанию следующий н
    issue и спеку (в том же PR), затем продолжай.
 4. **Неочевидные решения** по ходу — ADR (скилл adr), в том же PR.
 5. **PR — черновиком.** Коммить логическими шагами. `git push -u origin
-   <ветка>`, затем `gh pr create --draft`. **Заголовок PR — это будущий
-   squash-коммит в main** (merge делается со squash), по нему история main
+   <ветка>`, затем `gh pr create --draft`. **Заголовок PR — будущее
+   сообщение коммита в main** (при дефолтном squash-merge — squash-коммита;
+   метод приземления — производная `conventions.squash` ×
+   `conventions.branchUpdate`, см. docs/config.md), по нему история main
    читается как чейнджлог. Заголовок получает `commitType` типа задачи
    (шаг 1) — прочитай его из конфига:
    `${CLAUDE_PLUGIN_ROOT}/hooks/scripts/adk-config.sh types.<тип>.commitType <дефолт>`

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,7 +71,7 @@ exit-код; тот, кому не важна (значение не из зак
 | `policies.review.maxRounds` | число | `2` | Зарезервирован спекой, потребителя пока нет. Сегодняшний лимит «два круга ревью без APPROVE → зовём человека» зашит текстом в `commands/work.md` (шаг 6) и `commands/autopilot.md`; атрибут не читается. |
 | `policies.review.humanApprovalRequired` | bool | `false` | Вердикт даёт reviewer-агент; человек не обязан approve'ить PR отдельно. |
 | `policies.autopilot.enabled` | bool | `true` | `/autopilot` стартует без ограничений; `false` — отказ старта без побочных эффектов (читается в `commands/autopilot.md`, «Политика прогона»). |
-| `policies.autopilot.canMerge` | bool | `true` | `/autopilot` мержит ready-PR сам (`gh pr merge --squash --delete-branch`); `false` — ready-PR собираются в список «ждут человека» (`result=ready`, ADR-003). |
+| `policies.autopilot.canMerge` | bool | `true` | `/autopilot` мержит ready-PR сам (`gh pr merge <флаг> --delete-branch`, флаг — производная метода приземления, см. «Серверный метод приземления GitHub» ниже, не жёсткий `--squash`); `false` — ready-PR собираются в список «ждут человека» (`result=ready`, ADR-003). |
 | `policies.autopilot.maxTasksPerRun` | число | `5` | Лимит задач `/autopilot` за прогон; аргумент команды его переопределяет (`commands/autopilot.md`, «Параметры»). |
 
 `policies.merge` энфорсится хуком bash-guard (SPEC-002 AC-2): `human-only`

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -936,6 +936,29 @@ check_ac_doc AC-8 "autopilot.md: после актуализации гейты 
   "$KIT/commands/autopilot.md" "merge без перегона гейтов после актуализации запрещён"
 assert_contains "AC-8: work.md — конфликт при актуализации ведёт к остановке (не «разреши сам»)" "$work_step6" 'конфликт с main, остановись и позови пользователя'
 assert_contains "AC-8: autopilot.md — конфликт с main (CONFLICTING) ведёт к needs-human" "$autopilot_step3" 'конфликт с main требует человека.*needs-human'
+
+# ── issue #77 (хвост ревью PR #63, K16): флаг слияния — производная
+# метода приземления (adk-config.sh --merge-method), не жёсткий --squash —
+# иначе легальный conventions.squash=false сервер отклонит, и автопилот
+# застрянет на корректном конфиге. Дефолтное поведение (squash=true) не
+# меняется: --merge-method без конфига по-прежнему даёт squash-merge
+# (проверено секцией AC-6 ниже), маппинг на --squash сохранён явно.
+assert_contains "issue #77: autopilot.md выводит флаг merge через adk-config.sh --merge-method, не жёсткий --squash" "$autopilot_step3" 'adk-config\.sh --merge-method'
+assert_contains "issue #77: autopilot.md маппит squash-merge на --squash" "$autopilot_step3" 'squash-merge.*--squash'
+assert_contains "issue #77: autopilot.md маппит rebase-merge на --rebase" "$autopilot_step3" 'rebase-merge.*--rebase'
+assert_contains "issue #77: autopilot.md маппит merge-commit на --merge" "$autopilot_step3" 'merge-commit.*--merge'
+assert_not_contains "issue #77: autopilot.md не мержит жёстким --squash без вывода метода приземления" "$autopilot_step3" 'pr merge <PR> --squash --delete-branch'
+
+config_doc_text=$(tr '\n' ' ' < "$KIT/docs/config.md" | tr -s ' ')
+check_ac_doc "issue #77" "docs/config.md: canMerge выводит флаг merge из метода приземления, не жёсткий --squash" \
+  "$KIT/docs/config.md" "gh pr merge <флаг> --delete-branch"
+assert_not_contains "issue #77: docs/config.md canMerge не упоминает безусловный --squash в описании merge" "$config_doc_text" 'gh pr merge --squash --delete-branch'
+
+work_step5=$(md_section "$KIT/commands/work.md" '^5\. \*\*' '^6\. \*\*')
+check_ac_doc "issue #77" "work.md: формулировка «заголовок PR = squash-коммит» оговорена — верна при дефолтном squash-merge" \
+  "$KIT/commands/work.md" "при дефолтном squash-merge — squash-коммита"
+assert_not_contains "issue #77: work.md не утверждает безусловно «merge делается со squash»" "$work_step5" 'merge делается со squash'
+
 # /review — второй путь в ready: та же проверка актуальности (issue #68,
 # fast-follow из вердикта PR #67)
 review_ready=$(md_section "$KIT/commands/review.md" '^5\. \*\*' '^6\. \*\*')


### PR DESCRIPTION
Closes #77

## Что сделано

- `commands/autopilot.md` (шаг 3, merge ready-PR): флаг слияния теперь
  выводится из `adk-config.sh --merge-method` — `squash-merge` → `--squash`,
  `rebase-merge` → `--rebase`, `merge-commit` → `--merge` — вместо жёсткого
  `--squash`. При легальном `conventions.squash=false` сервер раньше
  отклонял squash-слияние, и автопилот застревал на корректном конфиге
  (хвост ревью PR #63, кандидат K16 инвентаризации).
- `docs/config.md` (`policies.autopilot.canMerge`): описание больше не
  упоминает безусловный `--squash`, ссылается на производную метода
  приземления.
- `commands/work.md` (шаг 5): формулировка «заголовок PR = сообщение
  squash-коммита» оговорена — верна при дефолтном squash-merge; в общем
  случае метод — производная `conventions.squash` × `conventions.branchUpdate`.

## Тесты

`tests/run.sh`, блок «issue #77» (9 тестов):
- autopilot.md выводит флаг через `adk-config.sh --merge-method` и явно
  маппит все три метода приземления; старый жёсткий фрагмент команды
  слияния с зашитым `--squash` больше не встречается;
- docs/config.md содержит новую формулировку с `<флаг>` вместо старой
  безусловной `--squash`;
- work.md содержит оговорку «при дефолтном squash-merge — squash-коммита»
  и не содержит старую безусловную «merge делается со squash».

Дефолтное поведение не изменилось: существующие AC-6 тесты
`adk_config_merge_method` (squash=true → squash-merge и т.д.) остались
зелёными без правок — используется уже существующая с PR #48/#63
инфраструктура `adk-config.sh --merge-method`, просто дописано её
подключение в autopilot.md.

`./scripts/check` и `./scripts/test` зелёные. ADR не потребовался — это
подключение уже существующей производной, а не новое архитектурное
решение.
